### PR TITLE
feat: implement toggleable plugin communication with eventyay

### DIFF
--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -1,2 +1,43 @@
-# Register your receivers here
-print("Interpretation plugin loaded")
+from django.dispatch import receiver
+from django.urls import resolve, reverse
+from django.utils.translation import gettext_lazy as _
+
+# ``nav_event_common`` powers the modern eventyay_common event dashboard
+# sidebar (shown next to the "Settings" and "Plugins" entries). It is an
+# ``EventPluginSignal``: eventyay only delivers it to receivers belonging to
+# plugins that are ENABLED for the current event. That is what makes this
+# navigation entry appear when the plugin is toggled on and disappear when it
+# is toggled off -- no extra wiring needed.
+from eventyay.control.signals import nav_event_common
+
+
+@receiver(nav_event_common, dispatch_uid="interpretation_nav_event_common")
+def navbar_entry_common(sender, request=None, **kwargs):
+    """Add an "Interpretation" item to the eventyay_common event dashboard.
+
+    ``sender`` is the event; the signal is only delivered while the plugin is
+    enabled for that event.
+    """
+    if not request.user.has_event_permission(
+        request.organizer,
+        request.event,
+        "can_change_event_settings",
+        request=request,
+    ):
+        return []
+
+    url = resolve(request.path_info)
+    return [
+        {
+            "label": _("Interpretation"),
+            "url": reverse(
+                "plugins:interpretation:dashboard",
+                kwargs={
+                    "event": request.event.slug,
+                    "organizer": request.event.organizer.slug,
+                },
+            ),
+            "active": url.namespace == "plugins:interpretation",
+            "icon": "language",
+        }
+    ]

--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -1,17 +1,11 @@
 from django.dispatch import receiver
 from django.urls import resolve, reverse
 from django.utils.translation import gettext_lazy as _
-
 from eventyay.control.signals import nav_event_common
 
 
 @receiver(nav_event_common, dispatch_uid="interpretation_nav_event_common")
 def navbar_entry_common(sender, request=None, **kwargs):
-    """Add an "Interpretation" item to the eventyay_common event dashboard.
-
-    ``sender`` is the event; the signal is only delivered while the plugin is
-    enabled for that event.
-    """
     if not request.user.has_event_permission(
         request.organizer,
         request.event,

--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -2,12 +2,6 @@ from django.dispatch import receiver
 from django.urls import resolve, reverse
 from django.utils.translation import gettext_lazy as _
 
-# ``nav_event_common`` powers the modern eventyay_common event dashboard
-# sidebar (shown next to the "Settings" and "Plugins" entries). It is an
-# ``EventPluginSignal``: eventyay only delivers it to receivers belonging to
-# plugins that are ENABLED for the current event. That is what makes this
-# navigation entry appear when the plugin is toggled on and disappear when it
-# is toggled off -- no extra wiring needed.
 from eventyay.control.signals import nav_event_common
 
 

--- a/interpretation/templates/interpretation/dashboard.html
+++ b/interpretation/templates/interpretation/dashboard.html
@@ -1,0 +1,65 @@
+{% extends "eventyay_common/event/base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Interpretation" %}{% endblock %}
+{% block content %}
+    <h1>{% trans "Interpretation" %}</h1>
+
+    <div class="alert alert-success">
+        {% blocktrans trimmed with event=event.name %}
+            The interpretation plugin is active and connected to <strong>{{ event }}</strong>.
+        {% endblocktrans %}
+    </div>
+
+    <p>
+        {% blocktrans trimmed %}
+            This page is provided by the interpretation plugin. It only appears while the
+            plugin is enabled for this event. Disable the plugin on the plugins page and this
+            navigation entry and page will disappear.
+        {% endblocktrans %}
+    </p>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% trans "Connection status" %}</h3>
+        </div>
+        <table class="table">
+            <tbody>
+                <tr>
+                    <th>{% trans "Plugin module" %}</th>
+                    <td><code>{{ plugin_module }}</code></td>
+                </tr>
+                <tr>
+                    <th>{% trans "Enabled for this event" %}</th>
+                    <td>
+                        {% if plugin_enabled %}
+                            <span class="label label-success">{% trans "Yes" %}</span>
+                        {% else %}
+                            <span class="label label-danger">{% trans "No" %}</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <th>{% trans "Event slug" %}</th>
+                    <td><code>{{ event.slug }}</code></td>
+                </tr>
+                <tr>
+                    <th>{% trans "Organizer" %}</th>
+                    <td>{{ event.organizer.name }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% trans "Active plugins for this event" %}</h3>
+        </div>
+        <ul class="list-group">
+            {% for plugin in active_plugins %}
+                <li class="list-group-item"><code>{{ plugin }}</code></li>
+            {% empty %}
+                <li class="list-group-item">{% trans "No plugins enabled." %}</li>
+            {% endfor %}
+        </ul>
+    </div>
+{% endblock %}

--- a/interpretation/templates/interpretation/dashboard.html
+++ b/interpretation/templates/interpretation/dashboard.html
@@ -10,13 +10,45 @@
         {% endblocktrans %}
     </div>
 
-    <p>
-        {% blocktrans trimmed %}
-            This page is provided by the interpretation plugin. It only appears while the
-            plugin is enabled for this event. Disable the plugin on the plugins page and this
-            navigation entry and page will disappear.
-        {% endblocktrans %}
-    </p>
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% trans "Event details" %}</h3>
+        </div>
+        <table class="table">
+            <tbody>
+                <tr>
+                    <th>{% trans "Event name" %}</th>
+                    <td>{{ event.name }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Event slug" %}</th>
+                    <td><code>{{ event.slug }}</code></td>
+                </tr>
+                <tr>
+                    <th>{% trans "Organizer" %}</th>
+                    <td>{{ event.organizer.name }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Starts" %}</th>
+                    <td>{{ event.date_from }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Ends" %}</th>
+                    <td>{{ event.date_to|default:"—" }}</td>
+                </tr>
+                {% if event.location %}
+                    <tr>
+                        <th>{% trans "Location" %}</th>
+                        <td>{{ event.location }}</td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <th>{% trans "Timezone" %}</th>
+                    <td>{{ event.timezone }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
     <div class="panel panel-default">
         <div class="panel-heading">
@@ -38,28 +70,7 @@
                         {% endif %}
                     </td>
                 </tr>
-                <tr>
-                    <th>{% trans "Event slug" %}</th>
-                    <td><code>{{ event.slug }}</code></td>
-                </tr>
-                <tr>
-                    <th>{% trans "Organizer" %}</th>
-                    <td>{{ event.organizer.name }}</td>
-                </tr>
             </tbody>
         </table>
-    </div>
-
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">{% trans "Active plugins for this event" %}</h3>
-        </div>
-        <ul class="list-group">
-            {% for plugin in active_plugins %}
-                <li class="list-group-item"><code>{{ plugin }}</code></li>
-            {% empty %}
-                <li class="list-group-item">{% trans "No plugins enabled." %}</li>
-            {% endfor %}
-        </ul>
     </div>
 {% endblock %}

--- a/interpretation/urls.py
+++ b/interpretation/urls.py
@@ -1,0 +1,26 @@
+from django.urls import path
+
+# Registering the converter import side-effect lets us use <orgslug:...>
+# in plugin URL patterns, exactly like the built-in plugins do.
+from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
+
+from .views import InterpretationDashboard
+
+# eventyay auto-discovers this module (eventyay.multidomain.maindomain_urlconf
+# iterates over every app config that has an ``EventyayPluginMeta`` and includes
+# its ``urlpatterns`` under the ``plugins:<app_label>`` namespace).
+#
+# The path is mounted under ``/common/...`` on purpose: the eventyay_common
+# context processor only builds the dashboard chrome (sidebar/nav) for requests
+# whose path starts with ``/common``. Keeping our page there lets it render
+# inside the same dashboard layout as the Settings/Plugins pages instead of the
+# legacy control layout.
+#
+# Reverse name for the dashboard: ``plugins:interpretation:dashboard``.
+urlpatterns = [
+    path(
+        "common/event/<orgslug:organizer>/<slug:event>/interpretation/",
+        InterpretationDashboard.as_view(),
+        name="dashboard",
+    ),
+]

--- a/interpretation/urls.py
+++ b/interpretation/urls.py
@@ -1,21 +1,11 @@
 from django.urls import path
 
-# Registering the converter import side-effect lets us use <orgslug:...>
-# in plugin URL patterns, exactly like the built-in plugins do.
+
 from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
 
 from .views import InterpretationDashboard
 
-# eventyay auto-discovers this module (eventyay.multidomain.maindomain_urlconf
-# iterates over every app config that has an ``EventyayPluginMeta`` and includes
-# its ``urlpatterns`` under the ``plugins:<app_label>`` namespace).
-#
-# The path is mounted under ``/common/...`` on purpose: the eventyay_common
-# context processor only builds the dashboard chrome (sidebar/nav) for requests
-# whose path starts with ``/common``. Keeping our page there lets it render
-# inside the same dashboard layout as the Settings/Plugins pages instead of the
-# legacy control layout.
-#
+
 # Reverse name for the dashboard: ``plugins:interpretation:dashboard``.
 urlpatterns = [
     path(

--- a/interpretation/urls.py
+++ b/interpretation/urls.py
@@ -1,12 +1,9 @@
 from django.urls import path
-
-
 from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
 
 from .views import InterpretationDashboard
 
 
-# Reverse name for the dashboard: ``plugins:interpretation:dashboard``.
 urlpatterns = [
     path(
         "common/event/<orgslug:organizer>/<slug:event>/interpretation/",

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -1,0 +1,55 @@
+from django.shortcuts import redirect
+from django.views.generic import TemplateView
+
+from eventyay.control.permissions import EventPermissionRequiredMixin
+
+# Module path of this plugin as seen by eventyay's app registry.
+# The plugin is installed as the top-level Django app ``interpretation``
+# (see the ``pretix.plugin`` entry point), so this is the value that ends up
+# in ``event.get_plugins()`` when the plugin is toggled on for an event.
+PLUGIN_MODULE = "interpretation"
+
+
+class InterpretationEnabledMixin:
+    """Gate a view behind the per-event plugin toggle.
+
+    The navigation entry already hides itself when the plugin is disabled
+    (because ``nav_event`` is an ``EventPluginSignal``). This mixin makes
+    direct URL access respect the same toggle: if the plugin is not enabled
+    for the current event, the user is bounced back to the plugins page
+    instead of seeing plugin UI.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        if PLUGIN_MODULE not in request.event.get_plugins():
+            return redirect(
+                "eventyay_common:event.plugins",
+                organizer=request.event.organizer.slug,
+                event=request.event.slug,
+            )
+        return super().dispatch(request, *args, **kwargs)
+
+
+class InterpretationDashboard(
+    InterpretationEnabledMixin,
+    EventPermissionRequiredMixin,
+    TemplateView,
+):
+    """Minimal landing page proving the eventyay <-> plugin link works.
+
+    It reads ``request.event`` (context shared by eventyay's middleware) to
+    show that the plugin is wired into the running event, and reports whether
+    the plugin is currently enabled for that event.
+    """
+
+    template_name = "interpretation/dashboard.html"
+    permission = "can_change_event_settings"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        event = self.request.event
+        ctx["event"] = event
+        ctx["plugin_module"] = PLUGIN_MODULE
+        ctx["plugin_enabled"] = PLUGIN_MODULE in event.get_plugins()
+        ctx["active_plugins"] = event.get_plugins()
+        return ctx

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -3,23 +3,10 @@ from django.views.generic import TemplateView
 
 from eventyay.control.permissions import EventPermissionRequiredMixin
 
-# Module path of this plugin as seen by eventyay's app registry.
-# The plugin is installed as the top-level Django app ``interpretation``
-# (see the ``pretix.plugin`` entry point), so this is the value that ends up
-# in ``event.get_plugins()`` when the plugin is toggled on for an event.
 PLUGIN_MODULE = "interpretation"
 
 
 class InterpretationEnabledMixin:
-    """Gate a view behind the per-event plugin toggle.
-
-    The navigation entry already hides itself when the plugin is disabled
-    (because ``nav_event`` is an ``EventPluginSignal``). This mixin makes
-    direct URL access respect the same toggle: if the plugin is not enabled
-    for the current event, the user is bounced back to the plugins page
-    instead of seeing plugin UI.
-    """
-
     def dispatch(self, request, *args, **kwargs):
         if PLUGIN_MODULE not in request.event.get_plugins():
             return redirect(
@@ -35,13 +22,6 @@ class InterpretationDashboard(
     EventPermissionRequiredMixin,
     TemplateView,
 ):
-    """Minimal landing page proving the eventyay <-> plugin link works.
-
-    It reads ``request.event`` (context shared by eventyay's middleware) to
-    show that the plugin is wired into the running event, and reports whether
-    the plugin is currently enabled for that event.
-    """
-
     template_name = "interpretation/dashboard.html"
     permission = "can_change_event_settings"
 
@@ -51,5 +31,4 @@ class InterpretationDashboard(
         ctx["event"] = event
         ctx["plugin_module"] = PLUGIN_MODULE
         ctx["plugin_enabled"] = PLUGIN_MODULE in event.get_plugins()
-        ctx["active_plugins"] = event.get_plugins()
         return ctx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.entry-points."pretix.plugin"]
-interpretation = "interpretation:PretixPluginMeta"
+interpretation = "interpretation"
 
 [project.entry-points."distutils.commands"]
 build = "pretix_plugin_build.build:CustomBuild"


### PR DESCRIPTION
this resolves #12 

# Add plugin communication layer for eventyay-interpretation

## What this PR does

Establishes the foundation for the eventyay-interpretation plugin to integrate with the eventyay common dashboard sidebar navigation, a dedicated dashboard page, and enable/disable toggle behavior.

## Changes

| File | Description |
|---|---|
| `interpretation/signals.py` | `nav_event_common` receiver that injects an *Interpretation* entry into the event dashboard sidebar |
| `interpretation/urls.py` | Route at `/common/event/<organizer>/<event>/interpretation/`, auto-discovered by eventyay |
| `interpretation/views.py` | `InterpretationDashboard` view with `InterpretationEnabledMixin`; redirects to plugins page if the plugin is disabled |
| `interpretation/templates/interpretation/dashboard.html` | Status page extending `eventyay_common/event/base.html` |
| `pyproject.toml` | Fixed dead `interpretation:PretixPluginMeta` entry-point reference |

## Behavior

- **Plugin enabled** → *Interpretation* appears in the sidebar; dashboard loads showing connection status.
- **Plugin disabled** → sidebar entry is absent; direct URL access redirects to the plugins settings page.

