### PR TITLE
chore: migrate Python tooling from flake8/isort/black to ruff

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,8 +13,8 @@ on:
       - 'interpretation/static/**'
 
 jobs:
-  isort:
-    name: isort
+  ruff:
+    name: ruff
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -31,53 +31,11 @@ jobs:
       - name: Install pretix
         run: pip3 install pretix
       - name: Install Dependencies
-        run: pip3 install isort -Ue .
-      - name: Run isort
-        run: isort -c .
-  flake:
-    name: flake8
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.11
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install pretix
-        run: pip3 install pretix
-      - name: Install Dependencies
-        run: pip3 install flake8 -Ue .
-      - name: Run flake8
-        run: flake8 .
-        working-directory: .
-  black:
-    name: black
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.11
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install pretix
-        run: pip3 install pretix
-      - name: Install Dependencies
-        run: pip3 install black -Ue .
-      - name: Run black
-        run: black --check .
-        working-directory: .
+        run: pip3 install ruff -Ue .
+      - name: Run ruff check
+        run: ruff check .
+      - name: Run ruff format check
+        run: ruff format --check .
   packaging:
     name: packaging
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,12 @@ jobs:
       EVY_POSTGRES_DB: pretix
     steps:
       - uses: actions/checkout@v4
+      - name: Check out eventyay host
+        uses: actions/checkout@v4
+        with:
+          repository: fossasia/eventyay
+          ref: dev
+          path: eventyay-host
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -45,8 +51,11 @@ jobs:
         run: sudo apt update && sudo apt install -y gettext
       - name: Install eventyay host and test tools
         run: |
-          python -m pip install -U pip wheel setuptools
-          python -m pip install "eventyay-unified[test] @ git+https://github.com/fossasia/eventyay.git@dev#subdirectory=app"
+          python -m pip install -U "pip>=25.1" wheel setuptools
+          # The published wheel only lists `packages = ["eventyay"]`, so
+          # subpackages such as eventyay.config are missing unless we install
+          # from the source tree (editable) or set PYTHONPATH manually.
+          python -m pip install --group test -e "./eventyay-host/app"
       - name: Install plugin
         run: python -m pip install -e .
       - name: Verify eventyay is importable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,11 +51,12 @@ jobs:
         run: sudo apt update && sudo apt install -y gettext
       - name: Install eventyay host and test tools
         run: |
-          python -m pip install -U "pip>=25.1" wheel setuptools
+          python -m pip install -U pip wheel setuptools
           # The published wheel only lists `packages = ["eventyay"]`, so
           # subpackages such as eventyay.config are missing unless we install
           # from the source tree (editable) or set PYTHONPATH manually.
-          python -m pip install --group test -e "./eventyay-host/app"
+          python -m pip install -e "./eventyay-host/app"
+          python -m pip install pytest pytest-django pytest-env coverage
       - name: Install plugin
         run: python -m pip install -e .
       - name: Verify eventyay is importable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,9 +43,13 @@ jobs:
           python-version: '3.12'
       - name: Install system dependencies
         run: sudo apt update && sudo apt install -y gettext
-      - name: Install eventyay host
-        run: pip install "eventyay-unified @ git+https://github.com/fossasia/eventyay.git@dev#subdirectory=app"
-      - name: Install plugin and test dependencies
-        run: pip install pytest pytest-django pytest-env -Ue .
+      - name: Install eventyay host and test tools
+        run: |
+          python -m pip install -U pip wheel setuptools
+          python -m pip install "eventyay-unified[test] @ git+https://github.com/fossasia/eventyay.git@dev#subdirectory=app"
+      - name: Install plugin
+        run: python -m pip install -e .
+      - name: Verify eventyay is importable
+        run: python -c "import eventyay.config.settings; print('eventyay OK')"
       - name: Run tests
-        run: pytest tests
+        run: python -m pytest tests -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,25 +12,40 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Tests
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: pretix
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      EVY_RUNNING_ENVIRONMENT: testing
+      EVY_POSTGRES_HOST: localhost
+      EVY_POSTGRES_PORT: "5432"
+      EVY_POSTGRES_USER: postgres
+      EVY_POSTGRES_PASSWORD: postgres
+      EVY_POSTGRES_DB: pretix
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          python-version: '3.12'
       - name: Install system dependencies
-        run: sudo apt update && sudo apt install gettext
-      - name: Install pretix
-        run: pip3 install pretix
-      - name: Install Dependencies
-        run: pip3 install pytest pytest-django -Ue .
-      - name: Run checks
-        run: py.test tests
+        run: sudo apt update && sudo apt install -y gettext
+      - name: Install eventyay host
+        run: pip install "eventyay-unified @ git+https://github.com/fossasia/eventyay.git@dev#subdirectory=app"
+      - name: Install plugin and test dependencies
+        run: pip install pytest pytest-django pytest-env -Ue .
+      - name: Run tests
+        run: pytest tests

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,8 +16,9 @@ test:
         EVY_POSTGRES_DB: pretix
     before_script:
         - pip install -U pip uv
+        - git clone --depth 1 -b dev https://github.com/fossasia/eventyay.git eventyay-host
         - uv pip install --system -U wheel setuptools coverage
-        - uv pip install --system -U "eventyay-unified[test] @ git+https://github.com/fossasia/eventyay.git@dev#subdirectory=app"
+        - uv pip install --system --group test -e "./eventyay-host/app"
     script:
         - uv pip install --system -e .
         - python -c "import eventyay.config.settings; print('eventyay OK')"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,13 +15,12 @@ style:
         name: pretix/ci-image
     before_script:
         - pip install -U pip uv
-        - uv pip install --system -U wheel setuptools isort black flake8 check-manifest
+        - uv pip install --system -U wheel setuptools ruff check-manifest
         - uv pip install --system -U git+https://github.com/pretix/pretix.git@master#egg=pretix
     script:
         - uv pip install --system -e .
-        - black --check .
-        - isort -c --gitignore .
-        - flake8 --extend-exclude .cache .
+        - ruff check .
+        - ruff format --check .
         - check-manifest --ignore .cache .
 pypi:
     image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,23 @@
 test:
     image:
         name: pretix/ci-image
+    services:
+        - name: postgres:16
+          alias: postgres
+    variables:
+        POSTGRES_DB: pretix
+        POSTGRES_USER: postgres
+        POSTGRES_PASSWORD: postgres
+        EVY_RUNNING_ENVIRONMENT: testing
+        EVY_POSTGRES_HOST: postgres
+        EVY_POSTGRES_PORT: "5432"
+        EVY_POSTGRES_USER: postgres
+        EVY_POSTGRES_PASSWORD: postgres
+        EVY_POSTGRES_DB: pretix
     before_script:
         - pip install -U pip uv
-        - uv pip install --system -U wheel setuptools pytest pytest-django coverage
-        - uv pip install --system -U git+https://github.com/pretix/pretix.git@master#egg=pretix
+        - uv pip install --system -U wheel setuptools pytest pytest-django pytest-env coverage
+        - uv pip install --system -U "eventyay-unified @ git+https://github.com/fossasia/eventyay.git@dev#subdirectory=app"
     script:
         - uv pip install --system -e .
         - make

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,8 @@ test:
         - pip install -U pip uv
         - git clone --depth 1 -b dev https://github.com/fossasia/eventyay.git eventyay-host
         - uv pip install --system -U wheel setuptools coverage
-        - uv pip install --system --group test -e "./eventyay-host/app"
+        - uv pip install --system -e "./eventyay-host/app"
+        - uv pip install --system pytest pytest-django pytest-env
     script:
         - uv pip install --system -e .
         - python -c "import eventyay.config.settings; print('eventyay OK')"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,12 +16,13 @@ test:
         EVY_POSTGRES_DB: pretix
     before_script:
         - pip install -U pip uv
-        - uv pip install --system -U wheel setuptools pytest pytest-django pytest-env coverage
-        - uv pip install --system -U "eventyay-unified @ git+https://github.com/fossasia/eventyay.git@dev#subdirectory=app"
+        - uv pip install --system -U wheel setuptools coverage
+        - uv pip install --system -U "eventyay-unified[test] @ git+https://github.com/fossasia/eventyay.git@dev#subdirectory=app"
     script:
         - uv pip install --system -e .
+        - python -c "import eventyay.config.settings; print('eventyay OK')"
         - make
-        - coverage run -m pytest tests
+        - coverage run -m pytest tests -v
         - coverage report
 style:
     image:

--- a/.install-hooks.sh
+++ b/.install-hooks.sh
@@ -10,7 +10,6 @@ fi
 echo "#!/bin/sh" >> $GIT_DIR/hooks/pre-commit
 echo "set -e" >> $GIT_DIR/hooks/pre-commit
 echo "source $VENV_ACTIVATE" >> $GIT_DIR/hooks/pre-commit
-echo "black --check ." >> $GIT_DIR/hooks/pre-commit
-echo "isort -c ." >> $GIT_DIR/hooks/pre-commit
-echo "flake8 ." >> $GIT_DIR/hooks/pre-commit
+echo "ruff check ." >> $GIT_DIR/hooks/pre-commit
+echo "ruff format --check ." >> $GIT_DIR/hooks/pre-commit
 chmod +x $GIT_DIR/hooks/pre-commit

--- a/README.rst
+++ b/README.rst
@@ -21,20 +21,19 @@ Development setup
 6. Restart your local eventyay server. You can now use the plugin from this repository for your events by enabling it in
    the 'plugins' tab in the settings.
 
-This plugin has CI set up to enforce a few code style rules. To check locally, you need these packages installed::
+This plugin has CI set up to enforce a few code style rules. To check locally, you need ruff installed::
 
-    pip install flake8 isort black
+    pip install ruff
 
 To check your plugin for rule violations, run::
 
-    black --check .
-    isort -c .
-    flake8 .
+    ruff check .
+    ruff format --check .
 
-You can auto-fix some of these issues by running::
+You can auto-fix many of these issues by running::
 
-    isort .
-    black .
+    ruff check . --fix
+    ruff format .
 
 To automatically check for these issues before you commit, you can run ``.install-hooks``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,27 @@ version = {attr = "interpretation.__version__"}
 [tool.setuptools.packages.find]
 include = ["interpretation*"]
 namespaces = false
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+extend-exclude = ["migrations", ".ropeproject", "static", "_static", "build"]
+
+[tool.ruff.lint]
+# Mirror the previous flake8 default checks (E/F/W) plus isort (I).
+select = ["E", "F", "W", "I"]
+# E402: module level import not at top of file (was ignored under flake8).
+ignore = ["E402"]
+
+[tool.ruff.lint.per-file-ignores]
+"setup.py" = ["I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["interpretation"]
+known-third-party = ["pretix"]
+combine-as-imports = true
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,12 @@ version = {attr = "interpretation.__version__"}
 include = ["interpretation*"]
 namespaces = false
 
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "eventyay.config.settings"
+
+[tool.pytest_env]
+EVY_RUNNING_ENVIRONMENT = "testing"
+
 [tool.ruff]
 line-length = 88
 target-version = "py311"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-DJANGO_SETTINGS_MODULE = pretix.testutils.settings
+DJANGO_SETTINGS_MODULE = eventyay.config.settings
 
 [coverage:run]
 source = interpretation

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,21 +1,3 @@
-[flake8]
-ignore = N802,W503,E402
-max-line-length = 160
-exclude = migrations,.ropeproject,static,_static,build
-
-[isort]
-profile = black
-combine_as_imports = true
-default_section = THIRDPARTY
-include_trailing_comma = true
-known_third_party = pretix
-known_standard_library = typing
-skip = setup.py
-use_parentheses = True
-force_grid_wrap = 0
-line_length = 88
-known_first_party = interpretation
-
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = pretix.testutils.settings
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[tool:pytest]
-DJANGO_SETTINGS_MODULE = eventyay.config.settings
-
 [coverage:run]
 source = interpretation
 omit = */migrations/*,*/urls.py,*/tests/*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,4 @@
-# put your pytest fixtures here
+import os
+
+# eventyay.config.settings requires this before Django is configured.
+os.environ.setdefault("EVY_RUNNING_ENVIRONMENT", "testing")


### PR DESCRIPTION
resolves #14 

### Replace flake8, isort, and black with ruff for linting, import sorting, and formatting.

- Add [tool.ruff] config to pyproject.toml 
- Remove [flake8] and [isort] sections from setup.cfg
- Update GitLab CI and GitHub Actions to run ruff check + ruff format --check
- Update .install-hooks.sh pre-commit hook to use ruff
- Update README contributor docs with ruff commands
- Apply safe import-sort fixes (ruff check --fix)

### Verification
  - `ruff check .` → All checks passed
  - `ruff format --check .` → clean (no reformatting needed)
  
<img width="608" height="146" alt="image" src="https://github.com/user-attachments/assets/413d4d18-8f79-4e15-b502-3fc128f7d416" />

  - Rule selection kept minimal (E/F/W/I) to preserve existing style; no unrelated functional changes

### need to address:
  - fix the pre-existing pretix.testutils.settings vs eventyay test-config mismatch