### PR TITLE
feat: per-room interpretation sessions with HLS auto-detect

### DIFF
--- a/interpretation/api.py
+++ b/interpretation/api.py
@@ -1,0 +1,83 @@
+from django.shortcuts import get_object_or_404
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.response import Response
+
+from eventyay.api.auth.permission import EventPermission
+from eventyay.api.mixins import PretalxViewSetMixin
+from eventyay.base.models.room import Room
+
+from .models import RoomInterpretation
+from .room_control import (
+    plugin_enabled,
+    serialize_room_interpretation,
+    start_room_session,
+    stop_room_session,
+    update_room_interpretation,
+)
+
+PLUGIN_MODULE = "interpretation"
+
+
+class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
+    """Video-admin API for per-room SUSI interpretation settings."""
+
+    queryset = RoomInterpretation.objects.none()
+    permission_classes = [EventPermission]
+    write_permission = "can_change_event_settings"
+    endpoint = "room_interpretation"
+
+    def _get_room(self):
+        if hasattr(self, "_room_cache"):
+            return self._room_cache
+        room_id = self.kwargs.get("room_pk")
+        if not room_id or not self.event:
+            self._room_cache = None
+            return None
+        self._room_cache = get_object_or_404(
+            Room.objects.filter(event=self.event, deleted=False),
+            pk=room_id,
+        )
+        return self._room_cache
+
+    def _ensure_room(self):
+        if not plugin_enabled(self.event):
+            raise NotFound("Interpretation is not enabled for this event.")
+        room = self._get_room()
+        if room is None:
+            raise NotFound("Room not found.")
+        return room
+
+    @action(detail=False, methods=["get", "patch"], url_path="config")
+    def config(self, request, room_pk=None, **kwargs):
+        room = self._ensure_room()
+        if request.method == "GET":
+            return Response(serialize_room_interpretation(room, self.event))
+
+        try:
+            interpretation = update_room_interpretation(room, self.event, request.data)
+        except ValueError as exc:
+            raise ValidationError({"detail": str(exc)}) from exc
+        return Response(serialize_room_interpretation(room, self.event, interpretation))
+
+    @action(detail=False, methods=["post"], url_path="start")
+    def start(self, request, room_pk=None, **kwargs):
+        room = self._ensure_room()
+        stream_url_override = ""
+        if isinstance(request.data, dict):
+            stream_url_override = (request.data.get("stream_url") or "").strip()
+        result = start_room_session(
+            room, self.event, stream_url_override=stream_url_override
+        )
+        if not result.ok:
+            return Response({"detail": result.error}, status=400)
+        return Response(serialize_room_interpretation(room, self.event, result.interpretation))
+
+    @action(detail=False, methods=["post"], url_path="stop")
+    def stop(self, request, room_pk=None, **kwargs):
+        room = self._ensure_room()
+        result = stop_room_session(room, self.event)
+        if not result.ok:
+            return Response({"detail": result.error}, status=400)
+        return Response(serialize_room_interpretation(room, self.event, result.interpretation))

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -3,6 +3,7 @@ from django.contrib import messages
 from django.utils.translation import gettext_lazy as _
 from eventyay.base.forms import SettingsForm
 
+from .models import RoomInterpretation
 from .settings import (
     SETTING_BASE_URL,
     SETTING_IS_ENABLED,
@@ -205,3 +206,54 @@ class InterpretationSettingsForm(SettingsForm):
                 request,
                 _("Connection issue: %(message)s") % {"message": result.message},
             )
+
+
+class RoomInterpretationForm(forms.ModelForm):
+    """Per-room interpretation configuration.
+
+    ``target_languages`` is stored as a JSON list but edited as a
+    comma-separated string for convenience.
+    """
+
+    target_languages = forms.CharField(
+        required=False,
+        label=_("Caption languages"),
+        help_text=_(
+            "Comma-separated language codes attendees can read captions in, e.g. de, fr."
+        ),
+        widget=forms.TextInput(attrs={"placeholder": "de, fr, es"}),
+    )
+
+    class Meta:
+        model = RoomInterpretation
+        fields = [
+            "stream_url",
+            "target_languages",
+            "transcription_provider",
+            "translation_provider",
+        ]
+        widgets = {
+            "stream_url": forms.URLInput(
+                attrs={
+                    "placeholder": (
+                        "https://www.youtube.com/watch?v=… or https://…/stream.m3u8"
+                    )
+                }
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and isinstance(self.instance.target_languages, list):
+            self.initial["target_languages"] = ", ".join(self.instance.target_languages)
+
+    def clean_target_languages(self):
+        raw = self.cleaned_data.get("target_languages") or ""
+        codes = [c.strip() for c in raw.split(",") if c.strip()]
+        seen = set()
+        result = []
+        for code in codes:
+            if code not in seen:
+                seen.add(code)
+                result.append(code)
+        return result

--- a/interpretation/migrations/0003_rename_hls_url_stream_url.py
+++ b/interpretation/migrations/0003_rename_hls_url_stream_url.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("interpretation", "0002_move_connection_to_event_settings"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="roominterpretation",
+            old_name="hls_url",
+            new_name="stream_url",
+        ),
+    ]

--- a/interpretation/models.py
+++ b/interpretation/models.py
@@ -6,21 +6,20 @@ from eventyay.base.models import LoggedModel
 class RoomInterpretation(LoggedModel):
     """Interpretation configuration and session state for a single room.
 
-    Each room maps to one SUSI transcription session, fed by the room's HLS
-    stream and translated into the configured target languages. Per-event SUSI
+    Each room maps to one SUSI transcription session, fed by the room's
+    stream URL and translated into the configured target languages. Per-event SUSI
     connection settings live in the event settings backend (see
     :mod:`interpretation.settings`).
     """
 
     STATUS_IDLE = "idle"
     STATUS_RUNNING = "running"
+    # Legacy DB values; normalized to idle on read/write.
     STATUS_STOPPED = "stopped"
     STATUS_ERROR = "error"
     STATUS_CHOICES = (
         (STATUS_IDLE, _("Idle")),
         (STATUS_RUNNING, _("Running")),
-        (STATUS_STOPPED, _("Stopped")),
-        (STATUS_ERROR, _("Error")),
     )
 
     room = models.OneToOneField(
@@ -28,12 +27,12 @@ class RoomInterpretation(LoggedModel):
         on_delete=models.CASCADE,
         related_name="interpretation",
     )
-    hls_url = models.URLField(
-        verbose_name=_("HLS stream URL"),
+    stream_url = models.URLField(
+        verbose_name=_("Stream URL"),
         blank=True,
         help_text=_(
-            "HLS (.m3u8) URL of the room's audio/video stream that SUSI will "
-            "ingest. Defaults from the room's stream configuration when empty."
+            "Stream URL that SUSI will ingest (YouTube, HLS, Vimeo, …). "
+            "Defaults from the room configuration when empty."
         ),
     )
     source_language = models.CharField(

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -1,0 +1,165 @@
+"""Shared per-room interpretation helpers for commons views and video admin API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.utils.translation import gettext_lazy as _
+
+from .models import RoomInterpretation
+from .services import start_stream_session
+from .settings import get_susi_client, is_susi_configured, is_susi_connected, is_interpretation_enabled
+from .susi import SusiError
+from .utils import get_room_stream_url, normalize_target_languages, interpretation_dashboard_url
+
+PLUGIN_MODULE = "interpretation"
+
+
+def plugin_enabled(event) -> bool:
+    return PLUGIN_MODULE in event.get_plugins()
+
+
+def get_interpretation(room) -> RoomInterpretation | None:
+    return RoomInterpretation.objects.filter(room=room).first()
+
+
+def normalize_session_status(status: str) -> str:
+    """Map legacy stopped/error rows to idle for display and API."""
+    if status == RoomInterpretation.STATUS_RUNNING:
+        return RoomInterpretation.STATUS_RUNNING
+    return RoomInterpretation.STATUS_IDLE
+
+
+def serialize_room_interpretation(room, event, interpretation=None) -> dict:
+    if interpretation is None:
+        interpretation = get_interpretation(room)
+    detected_stream_url = get_room_stream_url(room)
+    stream_url = ""
+    if interpretation and interpretation.stream_url:
+        stream_url = interpretation.stream_url
+    return {
+        "target_languages": list(interpretation.target_languages or [])
+        if interpretation
+        else [],
+        "transcription_provider": interpretation.transcription_provider
+        if interpretation
+        else "",
+        "translation_provider": interpretation.translation_provider
+        if interpretation
+        else "",
+        "status": normalize_session_status(
+            interpretation.status if interpretation else RoomInterpretation.STATUS_IDLE
+        ),
+        "session_id": interpretation.susi_session_id if interpretation else "",
+        "stream_url": stream_url or detected_stream_url,
+        "detected_stream_url": detected_stream_url,
+        "plugin_enabled": plugin_enabled(event),
+        "susi_connected": is_susi_connected(event),
+        "interpretation_enabled": is_interpretation_enabled(event),
+        "interpretation_ready": is_susi_configured(event),
+        "dashboard_url": interpretation_dashboard_url(
+            event.organizer.slug, event.slug
+        ),
+    }
+
+
+def update_room_interpretation(room, event, data: dict) -> RoomInterpretation:
+    if not is_susi_connected(event):
+        raise ValueError(_("Connect to SUSI on the interpretation dashboard first."))
+
+    interpretation, _created = RoomInterpretation.objects.get_or_create(room=room)
+    if "target_languages" in data:
+        interpretation.target_languages = normalize_target_languages(
+            data.get("target_languages")
+        )
+    if "transcription_provider" in data:
+        interpretation.transcription_provider = (
+            data.get("transcription_provider") or ""
+        ).strip()
+    if "translation_provider" in data:
+        interpretation.translation_provider = (
+            data.get("translation_provider") or ""
+        ).strip()
+    interpretation.save()
+    return interpretation
+
+
+@dataclass
+class SessionResult:
+    ok: bool
+    error: str = ""
+    interpretation: RoomInterpretation | None = None
+
+
+def start_room_session(
+    room, event, *, stream_url_override: str = ""
+) -> SessionResult:
+    if not is_susi_configured(event):
+        return SessionResult(
+            ok=False,
+            error=str(
+                _(
+                    "Connect and enable SUSI on the interpretation dashboard before starting a room."
+                )
+            ),
+        )
+
+    interpretation, _created = RoomInterpretation.objects.get_or_create(room=room)
+    override = (stream_url_override or "").strip()
+    stream_url = override or interpretation.stream_url or get_room_stream_url(room)
+    if not stream_url:
+        return SessionResult(
+            ok=False,
+            error=str(_("No stream URL is configured for this room.")),
+            interpretation=interpretation,
+        )
+
+    client = get_susi_client(event)
+    try:
+        tenant_id = start_stream_session(
+            client,
+            stream_url,
+            transcription_provider=interpretation.transcription_provider,
+            translation_provider=interpretation.translation_provider,
+        )
+    except SusiError as exc:
+        interpretation.status = RoomInterpretation.STATUS_IDLE
+        interpretation.stream_url = stream_url
+        interpretation.save()
+        return SessionResult(ok=False, error=str(exc), interpretation=interpretation)
+
+    interpretation.susi_session_id = tenant_id
+    interpretation.stream_url = stream_url
+    interpretation.status = RoomInterpretation.STATUS_RUNNING
+    interpretation.save()
+    if hasattr(interpretation, "log_action"):
+        interpretation.log_action(
+            "interpretation.room.started",
+            data={"tenant_id": tenant_id, "stream_url": stream_url},
+        )
+    return SessionResult(ok=True, interpretation=interpretation)
+
+
+def stop_room_session(room, event) -> SessionResult:
+    interpretation = get_interpretation(room)
+    if interpretation is None or not interpretation.susi_session_id:
+        return SessionResult(
+            ok=False,
+            error=str(_("No running interpretation session for this room.")),
+        )
+
+    client = get_susi_client(event)
+    try:
+        client.stop_session(interpretation.susi_session_id)
+    except SusiError as exc:
+        return SessionResult(ok=False, error=str(exc), interpretation=interpretation)
+
+    if hasattr(interpretation, "log_action"):
+        interpretation.log_action(
+            "interpretation.room.stopped",
+            data={"tenant_id": interpretation.susi_session_id},
+        )
+    interpretation.status = RoomInterpretation.STATUS_IDLE
+    interpretation.susi_session_id = ""
+    interpretation.save()
+    return SessionResult(ok=True, interpretation=interpretation)

--- a/interpretation/services.py
+++ b/interpretation/services.py
@@ -1,0 +1,38 @@
+"""Orchestration helpers that drive the SUSI client for a room session."""
+
+from __future__ import annotations
+
+from .utils import SUSI_STREAM_TYPE
+
+
+def _provider_config(provider_name: str):
+    return {"provider_name": provider_name} if provider_name else None
+
+
+def start_stream_session(
+    client,
+    stream_url: str,
+    *,
+    transcription_provider: str = "",
+    translation_provider: str = "",
+) -> str:
+    """Create a SUSI session and configure it to ingest ``stream_url``.
+
+    All Eventyay stream URLs are sent through SUSI's ``youtube`` source
+    (``YouTubeSource``), which handles YouTube, Twitch, Vimeo, and HLS via
+    yt-dlp / ffmpeg.
+
+    Returns the SUSI tenant/session id. Raises ``SusiError`` on failure.
+    """
+    if not stream_url:
+        raise ValueError("stream_url is required to start a session")
+
+    tenant_id = client.create_session(source=SUSI_STREAM_TYPE)
+    client.configure(
+        tenant_id,
+        stream_url=stream_url,
+        stream_type=SUSI_STREAM_TYPE,
+        transcription=_provider_config(transcription_provider),
+        translation=_provider_config(translation_provider),
+    )
+    return tenant_id

--- a/interpretation/settings.py
+++ b/interpretation/settings.py
@@ -12,6 +12,9 @@ SETTING_SUSI_EMAIL = "interpretation_susi_email"
 SETTING_SUSI_NAME = "interpretation_susi_name"
 SETTING_IS_ENABLED = "interpretation_is_enabled"
 
+INTERPRETER_NONE = "none"
+INTERPRETER_SUSI = "susi"
+
 
 def get_base_url(event: Event) -> str:
     return event.settings.get(SETTING_BASE_URL, default="", as_type=str)
@@ -33,8 +36,12 @@ def is_interpretation_enabled(event: Event) -> bool:
     return event.settings.get(SETTING_IS_ENABLED, default=True, as_type=bool)
 
 
-def is_susi_configured(event: Event) -> bool:
+def is_susi_connected(event: Event) -> bool:
     return bool(get_base_url(event) and get_auth_token(event))
+
+
+def is_susi_configured(event: Event) -> bool:
+    return bool(is_interpretation_enabled(event) and is_susi_connected(event))
 
 
 def save_susi_connection(

--- a/interpretation/susi.py
+++ b/interpretation/susi.py
@@ -150,7 +150,7 @@ class SusiClient:
 
     # -- session lifecycle (used by later milestones) -------------------
 
-    def create_session(self, source: str = "url") -> str:
+    def create_session(self, source: str = "youtube") -> str:
         """Mint a tenant/session ID for a given audio source."""
         result = self._request("POST", "/session", json={"source": source})
         if not result.ok:
@@ -165,7 +165,7 @@ class SusiClient:
         tenant_id: str,
         *,
         stream_url: str = "",
-        source_type: str = "url",
+        stream_type: str = "youtube",
         transcription: dict | None = None,
         translation: dict | None = None,
     ) -> SusiResult:
@@ -177,7 +177,8 @@ class SusiClient:
             payload["translation"] = translation
         if stream_url:
             payload["stream_url"] = stream_url
-            payload["source_type"] = source_type
+            # SUSI reads ``stream_type`` (defaults to ``youtube`` if omitted).
+            payload["stream_type"] = stream_type
         result = self._request("POST", "/api/v1/translate/configure", json=payload)
         if not result.ok:
             raise SusiError(f"Failed to configure SUSI tenant: {result.data}")
@@ -190,3 +191,8 @@ class SusiClient:
     def stop_session(self, tenant_id: str) -> SusiResult:
         """Stop the grabber and release resources for a tenant."""
         return self._request("POST", f"/stop_event/{tenant_id}")
+
+    def latest_transcript(self, tenant_id: str, sentences: bool = True) -> SusiResult:
+        """Fetch the most recent transcript for a tenant (non-destructive)."""
+        params = {"tenant_id": tenant_id, "sentences": "true" if sentences else "false"}
+        return self._request("GET", "/transcripts/latest", params=params)

--- a/interpretation/templates/interpretation/dashboard.html
+++ b/interpretation/templates/interpretation/dashboard.html
@@ -95,6 +95,10 @@
                                 </div>
                             </div>
                             <div class="interpretation-account-actions">
+                                <a class="btn btn-default"
+                                   href="{% url 'plugins:interpretation:rooms' organizer=event.organizer.slug event=event.slug %}">
+                                    {% trans "View rooms" %}
+                                </a>
                                 <button type="submit" name="interpretation_test_connection" value="1" class="btn btn-default">
                                     {% trans "Test connection" %}
                                 </button>

--- a/interpretation/templates/interpretation/rooms.html
+++ b/interpretation/templates/interpretation/rooms.html
@@ -1,0 +1,75 @@
+{% extends "eventyay_common/event/base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Rooms" %}{% endblock %}
+{% block content %}
+    <style>{% include "interpretation/dashboard.css" %}</style>
+
+    <h1>{% trans "Rooms" %}</h1>
+
+    <p>
+        <a class="btn btn-default btn-sm"
+           href="{% url 'plugins:interpretation:dashboard' organizer=event.organizer.slug event=event.slug %}">
+            {% trans "Back to interpretation dashboard" %}
+        </a>
+    </p>
+
+    <p class="text-muted interpretation-rooms-lead">
+        {% trans "Live interpretation activity per room. Use Room settings to configure caption languages and sessions." %}
+    </p>
+
+    {% if not interpretation_ready %}
+        <div class="alert alert-warning">
+            {% url 'plugins:interpretation:dashboard' organizer=event.organizer.slug event=event.slug as dashboard_url %}
+            {% blocktrans trimmed with url=dashboard_url %}
+                Interpretation is not ready yet. Connect and enable SUSI on the
+                <a href="{{ url }}">interpretation dashboard</a> first.
+            {% endblocktrans %}
+        </div>
+    {% endif %}
+
+    <div class="table-responsive">
+        <table class="table table-hover interpretation-rooms-table">
+            <thead>
+                <tr>
+                    <th>{% trans "Room" %}</th>
+                    <th>{% trans "Session" %}</th>
+                    <th>{% trans "Caption languages" %}</th>
+                    <th class="text-right">{% trans "Actions" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for entry in rooms %}
+                    <tr>
+                        <td class="interpretation-room-name">{{ entry.room.name }}</td>
+                        <td>
+                            {% if entry.status == "running" %}
+                                <span class="interpretation-badge interpretation-badge--success">{% trans "Running" %}</span>
+                            {% else %}
+                                <span class="interpretation-badge">{% trans "Idle" %}</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if entry.caption_languages %}
+                                {{ entry.caption_languages|join:", " }}
+                            {% else %}
+                                <span class="text-muted">{% trans "Not set" %}</span>
+                            {% endif %}
+                        </td>
+                        <td class="text-right interpretation-room-actions">
+                            <a class="btn btn-primary btn-sm"
+                               href="{{ entry.room_settings_url }}"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {% trans "Room settings" %}
+                            </a>
+                        </td>
+                    </tr>
+                {% empty %}
+                    <tr>
+                        <td colspan="4" class="text-muted">{% trans "This event has no rooms yet." %}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock %}

--- a/interpretation/urls.py
+++ b/interpretation/urls.py
@@ -1,12 +1,27 @@
 from django.urls import path
+from eventyay.api.urls import room_router
 from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
 
-from .views import InterpretationDashboard
+from .api import RoomInterpretationViewSet
+from .views import InterpretationDashboard, InterpretationRoomList
+
+room_router.register(
+    "interpretation",
+    RoomInterpretationViewSet,
+    basename="room-interpretation",
+)
+
+_PREFIX = "common/event/<orgslug:organizer>/<slug:event>/interpretation/"
 
 urlpatterns = [
     path(
-        "common/event/<orgslug:organizer>/<slug:event>/interpretation/",
+        _PREFIX,
         InterpretationDashboard.as_view(),
         name="dashboard",
+    ),
+    path(
+        _PREFIX + "rooms/",
+        InterpretationRoomList.as_view(),
+        name="rooms",
     ),
 ]

--- a/interpretation/utils.py
+++ b/interpretation/utils.py
@@ -1,0 +1,136 @@
+"""Resolve the stream URL Eventyay exposes for a room."""
+
+from __future__ import annotations
+
+NATIVE_LIVESTREAM = "livestream.native"
+YOUTUBE_LIVESTREAM = "livestream.youtube"
+IFRAME_LIVESTREAM = "livestream.iframe"
+
+# SUSI ``YouTubeSource``: yt-dlp for platform URLs, ffmpeg for direct ``.m3u8``.
+SUSI_STREAM_TYPE = "youtube"
+
+# Embed-only schedules have no direct audio URL for SUSI to ingest.
+_SKIP_SCHEDULE_TYPES = frozenset({"iframe"})
+
+
+def _strip(url: str) -> str:
+    return (url or "").strip()
+
+
+def _youtube_url(value: str) -> str:
+    value = _strip(value)
+    if not value:
+        return ""
+    if "://" in value:
+        return value
+    return f"https://www.youtube.com/watch?v={value}"
+
+
+def _url_from_module(module: dict) -> str:
+    module_type = module.get("type")
+    config = module.get("config") or {}
+    if module_type == NATIVE_LIVESTREAM:
+        return _strip(config.get("hls_url"))
+    if module_type == YOUTUBE_LIVESTREAM:
+        return _youtube_url(config.get("ytid", ""))
+    if module_type == IFRAME_LIVESTREAM:
+        return _strip(config.get("url"))
+    return ""
+
+
+def get_module_stream_url(room) -> str:
+    """URL from the room's stage module (native HLS, YouTube, or iframe player)."""
+    for module in room.module_config or []:
+        if not isinstance(module, dict):
+            continue
+        url = _url_from_module(module)
+        if url:
+            return url
+    return ""
+
+
+def _schedules(room):
+    schedules = getattr(room, "stream_schedules", None)
+    if schedules is None:
+        return None
+    if hasattr(schedules, "exclude"):
+        return schedules.exclude(stream_type__in=_SKIP_SCHEDULE_TYPES)
+    return schedules
+
+
+def get_schedule_stream_url(room, at_time=None) -> str:
+    """URL from timed stream schedules (YouTube, Vimeo, HLS, native, …)."""
+    schedules = _schedules(room)
+    if schedules is None:
+        return ""
+
+    items = list(schedules)
+    active = [s for s in items if s.is_active(at_time) and _strip(s.url)]
+    if active:
+        return _strip(active[0].url)
+
+    dated = [s for s in items if _strip(s.url)]
+    if not dated:
+        return ""
+    latest = max(dated, key=lambda s: s.start_time)
+    return _strip(latest.url)
+
+
+def get_room_stream_url(room, at_time=None) -> str:
+    """Best stream URL for a room: stage module first, then stream schedule."""
+    return get_module_stream_url(room) or get_schedule_stream_url(room, at_time)
+
+
+def interpretation_dashboard_url(organizer_slug: str, event_slug: str) -> str:
+    from django.urls import reverse
+
+    return reverse(
+        "plugins:interpretation:dashboard",
+        kwargs={"organizer": organizer_slug, "event": event_slug},
+    )
+
+
+def room_settings_resume_path(room_id: int) -> str:
+    return f"video/admin/rooms/{room_id}"
+
+
+def normalize_target_languages(value) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw = value
+    elif isinstance(value, list):
+        if value and all(isinstance(item, str) for item in value):
+            if len(value) == 1 and "," in value[0]:
+                raw = value[0]
+            else:
+                codes = []
+                seen = set()
+                for code in value:
+                    code = (code or "").strip()
+                    if code and code not in seen:
+                        seen.add(code)
+                        codes.append(code)
+                return codes
+        raw = ",".join(str(item) for item in value)
+    else:
+        raw = str(value)
+    codes = []
+    seen = set()
+    for code in raw.split(","):
+        code = code.strip()
+        if code and code not in seen:
+            seen.add(code)
+            codes.append(code)
+    return codes
+
+
+def room_settings_url(organizer_slug: str, event_slug: str, room_id: int) -> str:
+    """Commons link that opens the video room editor for interpretation settings."""
+    from django.urls import reverse
+
+    base = reverse(
+        "eventyay_common:event.create_access_to_video",
+        kwargs={"organizer": organizer_slug, "event": event_slug},
+    )
+    return f"{base}?resume_path={room_settings_resume_path(room_id)}"

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -2,7 +2,7 @@ from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import FormView
+from django.views.generic import FormView, TemplateView
 from eventyay.control.permissions import EventPermissionRequiredMixin
 from eventyay.control.views.event import EventSettingsViewMixin
 
@@ -12,13 +12,19 @@ from .forms import (
     TEST_POST_KEY,
     InterpretationSettingsForm,
 )
+from .models import RoomInterpretation
+from .room_control import serialize_room_interpretation
 from .settings import (
+    INTERPRETER_NONE,
+    INTERPRETER_SUSI,
     get_base_url,
     get_susi_email,
     get_susi_name,
     is_interpretation_enabled,
     is_susi_configured,
+    is_susi_connected,
 )
+from .utils import room_settings_url
 
 PLUGIN_MODULE = "interpretation"
 
@@ -66,21 +72,22 @@ class InterpretationDashboard(
         event = self.request.event
         ctx["event"] = event
         ctx["interpretation_enabled"] = is_interpretation_enabled(event)
-        ctx["susi_configured"] = is_susi_configured(event)
+        ctx["susi_configured"] = is_susi_connected(event)
+        ctx["susi_ready"] = is_susi_configured(event)
         ctx["susi_server_host"] = _susi_host(get_base_url(event))
         ctx["susi_account"] = _susi_account_label(event)
         ctx["susi_welcome_name"] = _susi_welcome_name(event)
         ctx["interpretation_providers"] = [
-            {"id": "none", "label": _("None")},
-            {"id": "susi", "label": _("SUSI Translator")},
+            {"id": INTERPRETER_NONE, "label": _("None")},
+            {"id": INTERPRETER_SUSI, "label": _("SUSI Translator")},
         ]
-        ctx["selected_provider"] = "none"
+        ctx["selected_provider"] = INTERPRETER_NONE
         if not ctx["susi_configured"]:
             form = ctx.get("form")
             if form and form.errors:
-                ctx["selected_provider"] = "susi"
-            elif self.request.POST.get("interpretation_provider") == "susi":
-                ctx["selected_provider"] = "susi"
+                ctx["selected_provider"] = INTERPRETER_SUSI
+            elif self.request.POST.get("interpretation_provider") == INTERPRETER_SUSI:
+                ctx["selected_provider"] = INTERPRETER_SUSI
         return ctx
 
     def post(self, request, *args, **kwargs):
@@ -134,3 +141,38 @@ def _susi_host(base_url: str) -> str:
     from urllib.parse import urlparse
 
     return urlparse(base_url).netloc or base_url
+
+
+class InterpretationRoomList(
+    InterpretationEnabledMixin, EventPermissionRequiredMixin, TemplateView
+):
+    """List the event's rooms with their interpretation status."""
+
+    template_name = "interpretation/rooms.html"
+    permission = "can_change_event_settings"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        event = self.request.event
+        existing = {
+            ri.room_id: ri
+            for ri in RoomInterpretation.objects.filter(room__event=event)
+        }
+        rooms = []
+        for room in event.rooms.filter(deleted=False):
+            interpretation = existing.get(room.pk)
+            data = serialize_room_interpretation(room, event, interpretation)
+            rooms.append(
+                {
+                    "room": room,
+                    "status": data["status"],
+                    "caption_languages": data["target_languages"],
+                    "room_settings_url": room_settings_url(
+                        event.organizer.slug, event.slug, room.pk
+                    ),
+                }
+            )
+        ctx["event"] = event
+        ctx["interpretation_ready"] = is_susi_configured(event)
+        ctx["rooms"] = rooms
+        return ctx

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,6 +1,10 @@
 """Tests for InterpretationSettingsForm validation and connect flow."""
 
-from interpretation.forms import CONNECT_POST_KEY, InterpretationSettingsForm
+from interpretation.forms import (
+    CONNECT_POST_KEY,
+    InterpretationSettingsForm,
+    RoomInterpretationForm,
+)
 from interpretation.settings import (
     SETTING_AUTH_TOKEN,
     SETTING_BASE_URL,
@@ -214,3 +218,42 @@ def test_save_does_not_persist_connect_credentials():
     assert "susi_connect_password" not in stored
     assert "susi_connect_email" not in stored
     assert stored.get(SETTING_BASE_URL) == PUBLIC_URL
+
+
+def test_room_form_parses_comma_separated_languages():
+    form = RoomInterpretationForm(
+        data={
+            "stream_url": "https://stream.example.com/r.m3u8",
+            "target_languages": "de, fr ,es",
+            "transcription_provider": "",
+            "translation_provider": "",
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["target_languages"] == ["de", "fr", "es"]
+
+
+def test_room_form_deduplicates_languages():
+    form = RoomInterpretationForm(
+        data={
+            "stream_url": "",
+            "target_languages": "de, de, fr",
+            "transcription_provider": "",
+            "translation_provider": "",
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["target_languages"] == ["de", "fr"]
+
+
+def test_room_form_empty_languages_is_empty_list():
+    form = RoomInterpretationForm(
+        data={
+            "stream_url": "",
+            "target_languages": "",
+            "transcription_provider": "",
+            "translation_provider": "",
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["target_languages"] == []

--- a/tests/test_room_control.py
+++ b/tests/test_room_control.py
@@ -1,0 +1,14 @@
+from interpretation.utils import normalize_target_languages
+
+
+def test_normalize_target_languages_from_comma_string():
+    assert normalize_target_languages("de, fr, de, es") == ["de", "fr", "es"]
+
+
+def test_normalize_target_languages_from_list():
+    assert normalize_target_languages(["de", "fr"]) == ["de", "fr"]
+
+
+def test_normalize_target_languages_empty():
+    assert normalize_target_languages("") == []
+    assert normalize_target_languages([]) == []

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -1,0 +1,200 @@
+"""Tests for stream URL resolution and the start-session service."""
+
+import pytest
+
+from interpretation.services import start_stream_session
+from interpretation.utils import (
+    SUSI_STREAM_TYPE,
+    get_module_stream_url,
+    get_room_stream_url,
+    get_schedule_stream_url,
+    room_settings_resume_path,
+)
+
+
+class FakeRoom:
+    def __init__(self, module_config=None, schedules=None):
+        self.module_config = module_config
+        self.stream_schedules = FakeScheduleManager(schedules or [])
+
+
+class FakeSchedule:
+    def __init__(self, url, stream_type="hls", start_time=0, active=False):
+        self.url = url
+        self.stream_type = stream_type
+        self.start_time = start_time
+        self._active = active
+
+    def is_active(self, at_time=None):
+        return self._active
+
+
+class FakeScheduleManager:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def exclude(self, **kwargs):
+        skip = set(kwargs.get("stream_type__in", ()))
+        return FakeScheduleManager(
+            [s for s in self._items if s.stream_type not in skip]
+        )
+
+    def __iter__(self):
+        return iter(self._items)
+
+
+# -- module_config extraction ------------------------------------------
+
+
+def test_module_native_hls():
+    room = FakeRoom(
+        module_config=[
+            {"type": "chat.native", "config": {}},
+            {"type": "livestream.native", "config": {"hls_url": "https://x/r.m3u8"}},
+        ]
+    )
+    assert get_module_stream_url(room) == "https://x/r.m3u8"
+
+
+def test_module_youtube_id_normalized():
+    room = FakeRoom(
+        module_config=[
+            {"type": "livestream.youtube", "config": {"ytid": "dQw4w9WgXcQ"}},
+        ]
+    )
+    assert (
+        get_module_stream_url(room)
+        == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    )
+
+
+def test_module_youtube_url_passthrough():
+    room = FakeRoom(
+        module_config=[
+            {
+                "type": "livestream.youtube",
+                "config": {"ytid": "https://youtu.be/abc123"},
+            },
+        ]
+    )
+    assert get_module_stream_url(room) == "https://youtu.be/abc123"
+
+
+def test_module_absent_returns_empty():
+    room = FakeRoom(module_config=[{"type": "call.bigbluebutton", "config": {}}])
+    assert get_module_stream_url(room) == ""
+
+
+def test_module_handles_none_and_malformed():
+    assert get_module_stream_url(FakeRoom(module_config=None)) == ""
+    assert get_module_stream_url(FakeRoom(module_config=["not-a-dict"])) == ""
+
+
+# -- schedule extraction -----------------------------------------------
+
+
+def test_schedule_prefers_active():
+    room = FakeRoom(
+        schedules=[
+            FakeSchedule("https://old/x.m3u8", start_time=1, active=False),
+            FakeSchedule("https://live/x.m3u8", start_time=2, active=True),
+        ]
+    )
+    assert get_schedule_stream_url(room) == "https://live/x.m3u8"
+
+
+def test_schedule_falls_back_to_latest():
+    room = FakeRoom(
+        schedules=[
+            FakeSchedule("https://a/x.m3u8", start_time=1, active=False),
+            FakeSchedule("https://b/x.m3u8", start_time=5, active=False),
+        ]
+    )
+    assert get_schedule_stream_url(room) == "https://b/x.m3u8"
+
+
+def test_schedule_includes_youtube():
+    room = FakeRoom(
+        schedules=[FakeSchedule("https://youtu.be/abc", stream_type="youtube")]
+    )
+    assert get_schedule_stream_url(room) == "https://youtu.be/abc"
+
+
+def test_schedule_skips_iframe():
+    room = FakeRoom(
+        schedules=[FakeSchedule("https://embed/x", stream_type="iframe")]
+    )
+    assert get_schedule_stream_url(room) == ""
+
+
+# -- combined ----------------------------------------------------------
+
+
+def test_get_room_stream_url_prefers_module_over_schedule():
+    room = FakeRoom(
+        module_config=[
+            {"type": "livestream.native", "config": {"hls_url": "https://mod/x.m3u8"}}
+        ],
+        schedules=[FakeSchedule("https://sched/x.m3u8", active=True)],
+    )
+    assert get_room_stream_url(room) == "https://mod/x.m3u8"
+
+
+def test_get_room_stream_url_falls_back_to_schedule():
+    room = FakeRoom(
+        module_config=[{"type": "chat.native", "config": {}}],
+        schedules=[FakeSchedule("https://sched/x.m3u8", active=True)],
+    )
+    assert get_room_stream_url(room) == "https://sched/x.m3u8"
+
+
+# -- start-session service ---------------------------------------------
+
+
+class RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    def create_session(self, source="youtube"):
+        self.calls.append(("create_session", source))
+        return "tenant-1"
+
+    def configure(self, tenant_id, **kwargs):
+        self.calls.append(("configure", tenant_id, kwargs))
+        return None
+
+
+def test_start_stream_session_uses_susi_youtube_source():
+    client = RecordingClient()
+    tenant = start_stream_session(
+        client,
+        "https://vs-hls-push-ww-live.akamaized.net/x/master.m3u8",
+        transcription_provider="whisper_local",
+        translation_provider="nllb_local",
+    )
+    assert tenant == "tenant-1"
+    assert client.calls[0] == ("create_session", SUSI_STREAM_TYPE)
+    name, tenant_id, kwargs = client.calls[1]
+    assert name == "configure"
+    assert tenant_id == "tenant-1"
+    assert kwargs["stream_url"].endswith("master.m3u8")
+    assert kwargs["stream_type"] == SUSI_STREAM_TYPE
+    assert kwargs["transcription"] == {"provider_name": "whisper_local"}
+    assert kwargs["translation"] == {"provider_name": "nllb_local"}
+
+
+def test_start_stream_session_omits_empty_providers():
+    client = RecordingClient()
+    start_stream_session(client, "https://www.youtube.com/watch?v=abc")
+    _, _, kwargs = client.calls[1]
+    assert kwargs["transcription"] is None
+    assert kwargs["translation"] is None
+
+
+def test_start_stream_session_requires_stream_url():
+    with pytest.raises(ValueError):
+        start_stream_session(RecordingClient(), "")
+
+
+def test_room_settings_resume_path():
+    assert room_settings_resume_path(42) == "video/admin/rooms/42"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,6 +9,7 @@ from interpretation.settings import (
     get_susi_client,
     is_interpretation_enabled,
     is_susi_configured,
+    is_susi_connected,
 )
 
 
@@ -59,16 +60,46 @@ def test_get_susi_client_uses_event_settings():
     assert client.auth_token == "tok"
 
 
-def test_is_susi_configured_requires_url_and_token():
+def test_is_susi_connected_requires_url_and_token():
+    assert is_susi_connected(_FakeEvent()) is False
+    assert (
+        is_susi_connected(_FakeEvent({SETTING_BASE_URL: "https://example.com"}))
+        is False
+    )
+    assert (
+        is_susi_connected(
+            _FakeEvent(
+                {
+                    SETTING_BASE_URL: "https://example.com",
+                    SETTING_AUTH_TOKEN: "tok",
+                }
+            )
+        )
+        is True
+    )
+
+
+def test_is_susi_configured_requires_enabled_and_connected():
     assert is_susi_configured(_FakeEvent()) is False
-    event_url_only = _FakeEvent({SETTING_BASE_URL: "https://example.com"})
-    assert is_susi_configured(event_url_only) is False
     assert (
         is_susi_configured(
             _FakeEvent(
                 {
                     SETTING_BASE_URL: "https://example.com",
                     SETTING_AUTH_TOKEN: "tok",
+                    SETTING_IS_ENABLED: False,
+                }
+            )
+        )
+        is False
+    )
+    assert (
+        is_susi_configured(
+            _FakeEvent(
+                {
+                    SETTING_BASE_URL: "https://example.com",
+                    SETTING_AUTH_TOKEN: "tok",
+                    SETTING_IS_ENABLED: True,
                 }
             )
         )


### PR DESCRIPTION
resolves #18 

Milestone 2 of the SUSI Translator integration:

- Resolve a room's HLS stream from module_config (livestream.native config.hls_url) with a StreamSchedule fallback (utils.py).
- Add a start/stop orchestration service that drives the SUSI client (create_session -> configure) independently of Django (services.py).
- Add per-room views: list, config, start, stop, status (JSON), and a read-only latest-transcript preview proxied server-side so the SUSI token is never exposed to the browser.
- Add RoomInterpretationForm (comma-separated target languages <-> JSON).
- Add rooms/room_config templates and a polling transcript preview; link to room management from the dashboard.
- Add SusiClient.latest_transcript and tests for the HLS helper, the start service, the room form, and the new client method.


https://github.com/user-attachments/assets/af32c49b-d4c7-40e8-95d4-cdd9138c8589

