### PR TITLE
Resolve unhandled 500 server crash by checking authentication in navbar signal

### DIFF
--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -6,6 +6,9 @@ from eventyay.control.signals import nav_event_common
 
 @receiver(nav_event_common, dispatch_uid="interpretation_nav_event_common")
 def navbar_entry_common(sender, request=None, **kwargs):
+    if not request or not request.user.is_authenticated:
+        return []
+
     if not request.user.has_event_permission(
         request.organizer,
         request.event,


### PR DESCRIPTION
## Description
This Pull Request fixes a critical stability issue (Denial of Service/Unhandled Exception) where unauthenticated users could crash the server by hitting a page that triggers the `nav_event_common` signal.

**The Issue:**
In `interpretation/signals.py`, the `navbar_entry_common` signal receiver was attempting to verify permissions directly on `request.user` without checking if the user was authenticated. For unauthenticated users, `request.user` evaluates to an `AnonymousUser` object, which lacks the `.has_event_permission()` custom method, resulting in an `AttributeError` and a 500 Internal Server Error.

**The Fix:**
I added a simple guard clause at the start of the function to verify that `request` is populated and that `request.user.is_authenticated` is True before proceeding with permission evaluation. If these conditions aren't met, it safely returns an empty list, hiding the navigation entry silently rather than crashing.

## Changes Made
* Added a guard clause `if not request or not request.user.is_authenticated: return []` to the `navbar_entry_common` receiver in `interpretation/signals.py`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Stability / Reliability patch

## Testing
- [x] Verified that the application no longer crashes when an unauthenticated user or anonymous session hits the `nav_event_common` signal.
- [x] Confirmed that the `Interpretation` tab still correctly displays for authenticated users with the appropriate `can_change_event_settings` permissions.

close #32

## Summary by Sourcery

Bug Fixes:
- Avoid calling custom permission checks on AnonymousUser in the navbar_event_common signal by short-circuiting when no authenticated request user is present.