### PR TITLE
Resolve unhandled 500 server crash on 404 pages caused by Resolver404 exception

### DIFF
--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -1,5 +1,5 @@
 from django.dispatch import receiver
-from django.urls import resolve, reverse
+from django.urls import Resolver404, resolve, reverse
 from django.utils.translation import gettext_lazy as _
 from eventyay.control.signals import nav_event_common
 
@@ -14,7 +14,12 @@ def navbar_entry_common(sender, request=None, **kwargs):
     ):
         return []
 
-    url = resolve(request.path_info)
+    try:
+        url = resolve(request.path_info)
+        is_active = (url.namespace == "plugins:interpretation")
+    except Resolver404:
+        is_active = False
+
     return [
         {
             "label": _("Interpretation"),
@@ -25,7 +30,7 @@ def navbar_entry_common(sender, request=None, **kwargs):
                     "organizer": request.event.organizer.slug,
                 },
             ),
-            "active": url.namespace == "plugins:interpretation",
+            "active": is_active,
             "icon": "language",
         }
     ]


### PR DESCRIPTION
## Description
This Pull Request fixes a critical stability issue where a 404 Not Found page within the event area would crash into a 500 Internal Server Error due to an unhandled exception in the navigation signal.

**The Issue:**
In `interpretation/signals.py`, the `navbar_entry_common` signal uses `django.urls.resolve(request.path_info)` to determine if the interpretation tab should be highlighted. If an authenticated user visits a non-existent URL, Django attempts to render the 404 page, which in turn fires the `nav_event_common` signal to build the navigation. During this process, `resolve()` raises a `Resolver404` exception because the URL does not exist. Since this was uncaught, the entire 404 page crashed, returning a 500 error instead.

**The Fix:**
I wrapped the `resolve(request.path_info)` call in a `try...except Resolver404` block. If the URL cannot be resolved, the code now gracefully falls back to assuming the interpretation tab is not active (`is_active = False`), allowing the 404 page to render properly without crashing.

## Changes Made
* Imported `Resolver404` from `django.urls`.
* Wrapped the URL resolution logic in `interpretation/signals.py` inside a `try...except` block to gracefully handle non-existent routes.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Stability / Reliability patch

## Testing
- [x] Verified that accessing a non-existent URL within the event control panel now correctly returns a standard 404 Not Found page instead of a 500 Internal Server Error.
- [x] Confirmed that the interpretation navigation tab still correctly highlights when legitimately accessed.

close #34

## Summary by Sourcery

Bug Fixes:
- Fix crash where unresolved URLs in the interpretation navigation signal caused 500 errors when rendering 404 pages.