### PR TITLE
Hide interpretation navigation tab for events where the plugin is disabled

### DIFF
--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -14,6 +14,9 @@ def navbar_entry_common(sender, request=None, **kwargs):
     ):
         return []
 
+    if "interpretation" not in request.event.get_plugins():
+        return []
+
     url = resolve(request.path_info)
     return [
         {


### PR DESCRIPTION
## Description
This Pull Request fixes a UX and logic bug where the "Interpretation" tab would appear in the sidebar navigation for all events, regardless of whether the plugin was actually enabled by the organizer.

**The Issue:**
In `interpretation/signals.py`, the `navbar_entry_common` signal checked for user permissions but failed to verify if the plugin was active for the current event. This resulted in the tab being universally visible. If an organizer clicked the tab for an event where the interpretation plugin was disabled, `InterpretationEnabledMixin` would abruptly redirect them back to the event plugins settings page, creating a confusing user experience.

**The Fix:**
I added a simple conditional check to ensure the plugin is active for the current event before returning the navigation dictionary.

## Changes Made
* Added an `if "interpretation" not in request.event.get_plugins(): return []` check to the `navbar_entry_common` signal receiver in `interpretation/signals.py`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UX / Usability improvement

## Testing
- [x] Verified that the "Interpretation" tab correctly appears in the navigation sidebar only for events where the plugin is explicitly enabled.
- [x] Confirmed that the tab is properly hidden for events where the plugin is disabled, preventing confusing redirect loops.

close #35 