### PR TITLE
feat: add SusiClient for SUSI Translator API

### DIFF
--- a/interpretation/susi.py
+++ b/interpretation/susi.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urljoin
+
+import requests
+
+DEFAULT_TIMEOUT = 10
+
+
+class SusiError(Exception):
+    """Raised when the SUSI server returns an error or is unreachable."""
+
+
+@dataclass
+class SusiResult:
+    ok: bool
+    status_code: int | None
+    data: dict
+    message: str = ""
+
+
+class SusiClient:
+    """Minimal client for talking to a SUSI Translator server."""
+
+    def __init__(
+        self, base_url: str, auth_token: str = "", timeout: int = DEFAULT_TIMEOUT
+    ):
+        if not base_url:
+            raise ValueError("base_url is required")
+        # Ensure a single trailing slash so urljoin treats it as a directory.
+        self.base_url = base_url.rstrip("/") + "/"
+        self.auth_token = auth_token or ""
+        self.timeout = timeout
+
+    # internals
+
+    def _url(self, path: str) -> str:
+        return urljoin(self.base_url, path.lstrip("/"))
+
+    def _headers(self) -> dict:
+        headers = {"Accept": "application/json"}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+        return headers
+
+    def _request(self, method: str, path: str, **kwargs) -> SusiResult:
+        url = self._url(path)
+        kwargs.setdefault("timeout", self.timeout)
+        kwargs.setdefault("headers", self._headers())
+        try:
+            resp = requests.request(method, url, **kwargs)
+        except requests.RequestException as exc:
+            raise SusiError(f"Could not reach SUSI server at {url}: {exc}") from exc
+
+        try:
+            data = resp.json() if resp.content else {}
+        except ValueError:
+            data = {}
+        return SusiResult(
+            ok=resp.ok,
+            status_code=resp.status_code,
+            data=data if isinstance(data, dict) else {"result": data},
+        )
+
+    # auth / health
+
+    def verify(self) -> SusiResult:
+        """Check reachability and token validity via ``/auth/api/status``."""
+        result = self._request("GET", "/auth/api/status")
+        if result.status_code is None or result.status_code >= 500:
+            result.ok = False
+            result.message = "SUSI server error or unreachable."
+            return result
+
+        authenticated = bool(result.data.get("authenticated"))
+        if not self.auth_token:
+            result.ok = False
+            result.message = "Server reachable but no authentication token configured."
+        elif authenticated:
+            result.ok = True
+            result.message = "Connected and authenticated."
+        else:
+            result.ok = False
+            result.message = "Server reachable but token is invalid or expired."
+        return result
+
+    def login(self, email: str, password: str) -> str:
+        """Authenticate with email/password and return the JWT access token."""
+        url = self._url("/auth/api/login")
+        try:
+            resp = requests.post(
+                url,
+                json={"email": email, "password": password},
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise SusiError(f"Could not reach SUSI server at {url}: {exc}") from exc
+
+        if not resp.ok:
+            raise SusiError("Invalid SUSI credentials or server rejected login.")
+
+        token = resp.cookies.get("access_token_cookie")
+        if not token:
+            raise SusiError("Login succeeded but no access token was returned.")
+        self.auth_token = token
+        return token
+
+    # session lifecycle (used by later milestones)
+
+    def create_session(self, source: str = "url") -> str:
+        """Mint a tenant/session ID for a given audio source."""
+        result = self._request("POST", "/session", json={"source": source})
+        if not result.ok:
+            raise SusiError(f"Failed to create SUSI session: {result.data}")
+        tenant_id = result.data.get("tenant_id")
+        if not tenant_id:
+            raise SusiError("SUSI did not return a tenant_id.")
+        return tenant_id
+
+    def configure(
+        self,
+        tenant_id: str,
+        *,
+        stream_url: str = "",
+        source_type: str = "url",
+        transcription: dict | None = None,
+        translation: dict | None = None,
+    ) -> SusiResult:
+        """Configure providers for a tenant and optionally start the grabber."""
+        payload: dict = {"tenant_id": tenant_id}
+        if transcription:
+            payload["transcription"] = transcription
+        if translation:
+            payload["translation"] = translation
+        if stream_url:
+            payload["stream_url"] = stream_url
+            payload["source_type"] = source_type
+        result = self._request("POST", "/api/v1/translate/configure", json=payload)
+        if not result.ok:
+            raise SusiError(f"Failed to configure SUSI tenant: {result.data}")
+        return result
+
+    def session_status(self, tenant_id: str) -> SusiResult:
+        """Poll whether a tenant's models are warmed up and ready."""
+        return self._request("GET", f"/api/v1/translate/status/{tenant_id}")
+
+    def stop_session(self, tenant_id: str) -> SusiResult:
+        """Stop the grabber and release resources for a tenant."""
+        return self._request("POST", f"/stop_event/{tenant_id}")

--- a/interpretation/urls.py
+++ b/interpretation/urls.py
@@ -3,7 +3,6 @@ from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
 
 from .views import InterpretationDashboard
 
-
 urlpatterns = [
     path(
         "common/event/<orgslug:organizer>/<slug:event>/interpretation/",

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -1,6 +1,5 @@
 from django.shortcuts import redirect
 from django.views.generic import TemplateView
-
 from eventyay.control.permissions import EventPermissionRequiredMixin
 
 PLUGIN_MODULE = "interpretation"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ maintainers = [
 ]
 
 dependencies = [
+    "requests>=2.31.0",
 ]
 
 [project.entry-points."pretix.plugin"]

--- a/tests/test_susi_client.py
+++ b/tests/test_susi_client.py
@@ -1,0 +1,136 @@
+"""Unit tests for the SUSI Translator API client (mocked HTTP)."""
+
+import pytest
+import requests
+
+from interpretation.susi import SusiClient, SusiError
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, json_data=None, cookies=None, content=b"{}"):
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else {}
+        self.cookies = cookies or {}
+        self.content = content
+
+    @property
+    def ok(self):
+        return 200 <= self.status_code < 400
+
+    def json(self):
+        return self._json
+
+
+def test_base_url_requires_value():
+    with pytest.raises(ValueError):
+        SusiClient("")
+
+
+def test_url_joining_handles_trailing_slash():
+    client = SusiClient("https://susi.example.com/")
+    assert client._url("/auth/api/status") == "https://susi.example.com/auth/api/status"
+    client2 = SusiClient("https://susi.example.com")
+    assert client2._url("auth/api/status") == "https://susi.example.com/auth/api/status"
+
+
+def test_headers_include_bearer_token_when_present():
+    assert "Authorization" not in SusiClient("https://x")._headers()
+    headers = SusiClient("https://x", "tok123")._headers()
+    assert headers["Authorization"] == "Bearer tok123"
+
+
+def test_verify_success(monkeypatch):
+    def fake_request(method, url, **kwargs):
+        assert method == "GET"
+        assert url.endswith("/auth/api/status")
+        assert kwargs["headers"]["Authorization"] == "Bearer good-token"
+        return FakeResponse(200, {"authenticated": True, "email": "a@b.c"})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    result = SusiClient("https://susi.example.com", "good-token").verify()
+    assert result.ok is True
+    assert result.status_code == 200
+
+
+def test_verify_invalid_token(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "request",
+        lambda *a, **k: FakeResponse(200, {"authenticated": False}),
+    )
+    result = SusiClient("https://susi.example.com", "bad-token").verify()
+    assert result.ok is False
+    assert "invalid" in result.message.lower() or "expired" in result.message.lower()
+
+
+def test_verify_without_token(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "request",
+        lambda *a, **k: FakeResponse(200, {"authenticated": False}),
+    )
+    result = SusiClient("https://susi.example.com").verify()
+    assert result.ok is False
+    assert "token" in result.message.lower()
+
+
+def test_verify_server_error(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "request",
+        lambda *a, **k: FakeResponse(503, {}),
+    )
+    result = SusiClient("https://susi.example.com", "tok").verify()
+    assert result.ok is False
+
+
+def test_verify_unreachable_raises(monkeypatch):
+    def boom(*a, **k):
+        raise requests.ConnectionError("refused")
+
+    monkeypatch.setattr(requests, "request", boom)
+    with pytest.raises(SusiError):
+        SusiClient("https://susi.example.com", "tok").verify()
+
+
+def test_login_returns_token_from_cookie(monkeypatch):
+    def fake_post(url, **kwargs):
+        assert url.endswith("/auth/api/login")
+        assert kwargs["json"] == {"email": "a@b.c", "password": "secret"}
+        return FakeResponse(
+            200, {"status": "success"}, cookies={"access_token_cookie": "jwt-xyz"}
+        )
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    client = SusiClient("https://susi.example.com")
+    token = client.login("a@b.c", "secret")
+    assert token == "jwt-xyz"
+    assert client.auth_token == "jwt-xyz"
+
+
+def test_login_rejects_bad_credentials(monkeypatch):
+    monkeypatch.setattr(
+        requests, "post", lambda *a, **k: FakeResponse(401, {"status": "error"})
+    )
+    with pytest.raises(SusiError):
+        SusiClient("https://susi.example.com").login("a@b.c", "wrong")
+
+
+def test_create_session_returns_tenant_id(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "request",
+        lambda *a, **k: FakeResponse(200, {"tenant_id": "abc123", "source": "url"}),
+    )
+    tenant = SusiClient("https://susi.example.com", "tok").create_session("url")
+    assert tenant == "abc123"
+
+
+def test_create_session_failure_raises(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "request",
+        lambda *a, **k: FakeResponse(400, {"error": "bad source"}),
+    )
+    with pytest.raises(SusiError):
+        SusiClient("https://susi.example.com", "tok").create_session("nope")


### PR DESCRIPTION
resolves #42 

## Summary
  Introduces a thin HTTP client for the [SUSI Translator](https://github.com/fossasia/susi_translator) Flask API. This is the foundation for the interpretation plugin, later PRs will wire Django models, forms, and the commons dashboard on top of this client.

No user-facing UI changes in this PR. Only the client library and its unit tests.

  ## What's included
  ### `interpretation/susi.py` (new)
  - **`SusiClient`** — minimal wrapper around the SUSI REST API
  - **JWT via `Authorization: Bearer`** avoids cookie-based auth and CSRF complexity
  - **`SusiError`** / **`SusiResult`** — typed errors and structured responses for callers

```text
SusiClient
│
├── Stores configuration
│   ├── base_url
│   ├── auth_token
│   └── timeout
│
├── Helper methods
│   ├── _url()
│   ├── _headers()
│   └── _request()
│
└── Public API methods
    ├── login()
    ├── verify()
    ├── create_session()
    ├── configure()
    ├── session_status()
    └── stop_session()
```
 
  **Endpoints covered:**

  | Method | Path | Purpose |
  |--------|------|---------|
  | `GET` | `/auth/api/status` | Verify token / connection |
  | `POST` | `/auth/api/login` | Email/password login → JWT |
  | `POST` | `/session` | Create transcription session |
  | `POST` | `/api/v1/translate/configure` | Configure translation |
  | `GET` | `/api/v1/translate/status/<tenant_id>` | Session status |
  | `POST` | `/stop_event/<tenant_id>` | Stop session |

  **Public API:** `verify()`, `login()`, `create_session()`, `configure()`, `session_status()`, `stop_session()`

  ### `tests/test_susi_client.py` (new)
  Mocked HTTP tests (no live SUSI server required):
  - Base URL validation and trailing-slash handling
  - Bearer token header construction
  - `verify()` success/failure paths
  - `login()` token extraction
  - Network error → `SusiError`

  ## How to test
  - [ ] `ruff check .` passes
  - [ ] `pytest tests/test_susi_client.py` passes
  - [ ] No migrations in this PR, nothing to run beyond tests

  ## Notes
  - First PR in the milestone-1 stack. **Merge before PR 2**(`m1-models-dashboard-scaffold`), which imports `SusiClient`.
  - Follow-up PRs will add models, event settings, email/password login, and dashboard UX.