### PR TITLE
refactor: store SUSI connection in per-event settings

### DIFF
--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -1,34 +1,72 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
+from eventyay.base.forms import SECRET_REDACTED, SecretKeySettingsField, SettingsForm
 
-from .models import SusiConnection
+from .settings import (
+    SETTING_AUTH_TOKEN,
+    SETTING_BASE_URL,
+    SETTING_IS_ENABLED,
+)
 
 
-class SusiConnectionForm(forms.ModelForm):
+class InterpretationSettingsForm(SettingsForm):
     """Per-event SUSI server connection settings."""
 
-    class Meta:
-        model = SusiConnection
-        fields = ["base_url", "auth_token", "is_enabled"]
-        widgets = {
-            "base_url": forms.URLInput(
-                attrs={"placeholder": "https://susi.example.com"}
-            ),
-            "auth_token": forms.PasswordInput(
-                render_value=True,
-                attrs={"autocomplete": "off"},
-            ),
-        }
+    interpretation_base_url = forms.URLField(
+        label=_("SUSI server URL"),
+        help_text=_(
+            "Base URL of the SUSI Translator Flask server, "
+            "e.g. https://susi.example.com"
+        ),
+        required=False,
+        widget=forms.URLInput(attrs={"placeholder": "https://susi.example.com"}),
+    )
+    interpretation_auth_token = SecretKeySettingsField(
+        label=_("Authentication token"),
+        help_text=_(
+            "JWT or long-lived token used to authenticate against the SUSI "
+            "server. Sent as a Bearer token; never exposed to attendees."
+        ),
+        required=False,
+    )
+    interpretation_is_enabled = forms.BooleanField(
+        label=_("Enable interpretation"),
+        help_text=_("Master switch for SUSI interpretation on this event."),
+        required=False,
+    )
 
-    def clean_base_url(self):
-        url = (self.cleaned_data.get("base_url") or "").strip()
+    def _stored_auth_token(self) -> str:
+        if not self.obj:
+            return ""
+        return self.obj.settings.get(SETTING_AUTH_TOKEN, default="", as_type=str)
+
+    def clean_interpretation_auth_token(self):
+        token = (self.cleaned_data.get(SETTING_AUTH_TOKEN) or "").strip()
+        if token == SECRET_REDACTED:
+            token = (self._stored_auth_token() or self.initial.get(SETTING_AUTH_TOKEN) or "").strip()
+        return token
+
+    def clean_interpretation_base_url(self):
+        url = (self.cleaned_data.get("interpretation_base_url") or "").strip()
         return url.rstrip("/")
 
     def clean(self):
         cleaned = super().clean()
-        if cleaned.get("is_enabled") and not cleaned.get("auth_token"):
-            self.add_error(
-                "auth_token",
-                _("An authentication token is required to enable interpretation."),
-            )
+        if cleaned.get(SETTING_IS_ENABLED):
+            if not cleaned.get(SETTING_BASE_URL):
+                self.add_error(
+                    SETTING_BASE_URL,
+                    _("A SUSI server URL is required to enable interpretation."),
+                )
+            token = cleaned.get(SETTING_AUTH_TOKEN)
+            if not token:
+                self.add_error(
+                    SETTING_AUTH_TOKEN,
+                    _("An authentication token is required to enable interpretation."),
+                )
         return cleaned
+
+    def save(self):
+        if self.cleaned_data.get(SETTING_AUTH_TOKEN) == SECRET_REDACTED:
+            self.cleaned_data[SETTING_AUTH_TOKEN] = self._stored_auth_token()
+        return super().save()

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -43,7 +43,9 @@ class InterpretationSettingsForm(SettingsForm):
     def clean_interpretation_auth_token(self):
         token = (self.cleaned_data.get(SETTING_AUTH_TOKEN) or "").strip()
         if token == SECRET_REDACTED:
-            token = (self._stored_auth_token() or self.initial.get(SETTING_AUTH_TOKEN) or "").strip()
+            token = (
+                self._stored_auth_token() or self.initial.get(SETTING_AUTH_TOKEN) or ""
+            ).strip()
         return token
 
     def clean_interpretation_base_url(self):

--- a/interpretation/migrations/0002_move_connection_to_event_settings.py
+++ b/interpretation/migrations/0002_move_connection_to_event_settings.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+
+def copy_connection_settings_to_event(apps, schema_editor):
+    SusiConnection = apps.get_model("interpretation", "SusiConnection")
+    if not SusiConnection.objects.exists():
+        return
+
+    from eventyay.base.models import Event
+
+    for connection in SusiConnection.objects.iterator():
+        event = Event.objects.get(pk=connection.event_id)
+        event.settings.set("interpretation_base_url", connection.base_url)
+        event.settings.set("interpretation_auth_token", connection.auth_token or "")
+        event.settings.set("interpretation_is_enabled", connection.is_enabled)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("interpretation", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            copy_connection_settings_to_event,
+            migrations.RunPython.noop,
+        ),
+        migrations.RemoveField(
+            model_name="roominterpretation",
+            name="connection",
+        ),
+        migrations.DeleteModel(
+            name="SusiConnection",
+        ),
+    ]

--- a/interpretation/models.py
+++ b/interpretation/models.py
@@ -3,50 +3,14 @@ from django.utils.translation import gettext_lazy as _
 from eventyay.base.models import LoggedModel
 
 
-class SusiConnection(LoggedModel):
-    """Per-event connection settings for a SUSI Translator instance."""
-
-    event = models.OneToOneField(
-        "base.Event",
-        on_delete=models.CASCADE,
-        related_name="susi_connection",
-    )
-    base_url = models.URLField(
-        verbose_name=_("SUSI server URL"),
-        help_text=_(
-            "Base URL of the SUSI Translator Flask server, "
-            "e.g. https://susi.example.com"
-        ),
-    )
-    auth_token = models.TextField(
-        verbose_name=_("Authentication token"),
-        blank=True,
-        help_text=_(
-            "JWT or long-lived token used to authenticate against the SUSI "
-            "server. Sent as a Bearer token; never exposed to attendees."
-        ),
-    )
-    is_enabled = models.BooleanField(
-        verbose_name=_("Enable interpretation"),
-        default=False,
-        help_text=_("Master switch for SUSI interpretation on this event."),
-    )
-
-    class Meta:
-        verbose_name = _("SUSI connection")
-        verbose_name_plural = _("SUSI connections")
-
-    def __str__(self):
-        return f"SusiConnection(event={self.event_id}, url={self.base_url})"
-
-    @property
-    def normalized_base_url(self):
-        """Base URL without a trailing slash, for safe path joining."""
-        return self.base_url.rstrip("/")
-
-
 class RoomInterpretation(LoggedModel):
-    """Interpretation configuration and session state for a single room."""
+    """Interpretation configuration and session state for a single room.
+
+    Each room maps to one SUSI transcription session, fed by the room's HLS
+    stream and translated into the configured target languages. Per-event SUSI
+    connection settings live in the event settings backend (see
+    :mod:`interpretation.settings`).
+    """
 
     STATUS_IDLE = "idle"
     STATUS_RUNNING = "running"
@@ -59,11 +23,6 @@ class RoomInterpretation(LoggedModel):
         (STATUS_ERROR, _("Error")),
     )
 
-    connection = models.ForeignKey(
-        SusiConnection,
-        on_delete=models.CASCADE,
-        related_name="rooms",
-    )
     room = models.OneToOneField(
         "base.Room",
         on_delete=models.CASCADE,

--- a/interpretation/settings.py
+++ b/interpretation/settings.py
@@ -1,0 +1,27 @@
+"""Per-event SUSI connection settings stored in the event settings backend."""
+
+from __future__ import annotations
+
+from eventyay.base.models import Event
+
+from .susi import SusiClient
+
+SETTING_BASE_URL = "interpretation_base_url"
+SETTING_AUTH_TOKEN = "interpretation_auth_token"
+SETTING_IS_ENABLED = "interpretation_is_enabled"
+
+
+def get_base_url(event: Event) -> str:
+    return event.settings.get(SETTING_BASE_URL, default="", as_type=str)
+
+
+def get_auth_token(event: Event) -> str:
+    return event.settings.get(SETTING_AUTH_TOKEN, default="", as_type=str)
+
+
+def is_interpretation_enabled(event: Event) -> bool:
+    return event.settings.get(SETTING_IS_ENABLED, default=False, as_type=bool)
+
+
+def get_susi_client(event: Event) -> SusiClient:
+    return SusiClient(get_base_url(event), get_auth_token(event))

--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -1,7 +1,18 @@
 from django.dispatch import receiver
 from django.urls import resolve, reverse
 from django.utils.translation import gettext_lazy as _
+from eventyay.base.settings import settings_hierarkey
 from eventyay.control.signals import nav_event_common
+
+from .settings import (
+    SETTING_AUTH_TOKEN,
+    SETTING_BASE_URL,
+    SETTING_IS_ENABLED,
+)
+
+settings_hierarkey.add_default(SETTING_BASE_URL, "", str)
+settings_hierarkey.add_default(SETTING_AUTH_TOKEN, "", str)
+settings_hierarkey.add_default(SETTING_IS_ENABLED, False, bool)
 
 
 @receiver(nav_event_common, dispatch_uid="interpretation_nav_event_common")

--- a/interpretation/templates/interpretation/dashboard.html
+++ b/interpretation/templates/interpretation/dashboard.html
@@ -17,9 +17,9 @@
         {% bootstrap_form_errors form %}
         <fieldset>
             <legend>{% trans "SUSI server connection" %}</legend>
-            {% bootstrap_field form.base_url layout='horizontal' %}
-            {% bootstrap_field form.auth_token layout='horizontal' %}
-            {% bootstrap_field form.is_enabled layout='horizontal' %}
+            {% bootstrap_field form.interpretation_base_url layout='horizontal' %}
+            {% bootstrap_field form.interpretation_auth_token layout='horizontal' %}
+            {% bootstrap_field form.interpretation_is_enabled layout='horizontal' %}
         </fieldset>
 
         <div class="form-group">
@@ -53,7 +53,7 @@
                 <tr>
                     <th>{% trans "Interpretation enabled" %}</th>
                     <td>
-                        {% if connection.is_enabled %}
+                        {% if interpretation_enabled %}
                             <span class="label label-success">{% trans "Yes" %}</span>
                         {% else %}
                             <span class="label label-default">{% trans "No" %}</span>

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -10,8 +10,8 @@ from .forms import InterpretationSettingsForm
 from .settings import (
     SETTING_AUTH_TOKEN,
     SETTING_BASE_URL,
-    is_interpretation_enabled,
     get_base_url,
+    is_interpretation_enabled,
 )
 from .susi import SusiClient, SusiError
 

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -1,12 +1,18 @@
 from django.contrib import messages
+from django.db import transaction
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import FormView
-from eventyay.control.permissions import EventPermissionRequiredMixin
+from eventyay.base.models import Event
+from eventyay.control.views.event import EventSettingsFormView, EventSettingsViewMixin
 
-from .forms import SusiConnectionForm
-from .models import SusiConnection
+from .forms import InterpretationSettingsForm
+from .settings import (
+    SETTING_AUTH_TOKEN,
+    SETTING_BASE_URL,
+    is_interpretation_enabled,
+    get_base_url,
+)
 from .susi import SusiClient, SusiError
 
 PLUGIN_MODULE = "interpretation"
@@ -25,23 +31,15 @@ class InterpretationEnabledMixin:
 
 class InterpretationDashboard(
     InterpretationEnabledMixin,
-    EventPermissionRequiredMixin,
-    FormView,
+    EventSettingsViewMixin,
+    EventSettingsFormView,
 ):
     """Configure the per-event SUSI connection and test connectivity."""
 
+    model = Event
     template_name = "interpretation/dashboard.html"
     permission = "can_change_event_settings"
-    form_class = SusiConnectionForm
-
-    def get_object(self):
-        connection = SusiConnection.objects.filter(event=self.request.event).first()
-        return connection
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["instance"] = self.get_object()
-        return kwargs
+    form_class = InterpretationSettingsForm
 
     def get_success_url(self):
         return reverse(
@@ -58,30 +56,43 @@ class InterpretationDashboard(
         ctx["event"] = event
         ctx["plugin_module"] = PLUGIN_MODULE
         ctx["plugin_enabled"] = PLUGIN_MODULE in event.get_plugins()
-        ctx["connection"] = self.get_object()
+        ctx["interpretation_enabled"] = is_interpretation_enabled(event)
         return ctx
 
-    def form_valid(self, form):
-        connection = form.save(commit=False)
-        connection.event = self.request.event
-        connection.save()
+    @transaction.atomic
+    def post(self, request, *args, **kwargs):
+        form = self.get_form()
+        if form.is_valid():
+            form.save()
+            self._save_decoupled(form)
+            if form.has_changed():
+                request.event.log_action(
+                    "eventyay.event.settings",
+                    user=request.user,
+                    data={
+                        k: form.cleaned_data.get(k)
+                        for k in form.changed_data
+                        if k != "interpretation_auth_token"
+                    },
+                )
+            if "test" in request.POST:
+                self._test_connection(form)
+            else:
+                messages.success(request, _("Connection settings saved."))
+            return redirect(self.get_success_url())
 
-        # "Save and test" button performs an immediate connectivity check.
-        if "test" in self.request.POST:
-            self._test_connection(connection)
-        else:
-            messages.success(self.request, _("Connection settings saved."))
-        return redirect(self.get_success_url())
-
-    def form_invalid(self, form):
         messages.error(
-            self.request,
+            request,
             _("Please correct the errors below before saving."),
         )
-        return super().form_invalid(form)
+        return self.render_to_response(self.get_context_data(form=form))
 
-    def _test_connection(self, connection):
-        client = SusiClient(connection.base_url, connection.auth_token)
+    def _test_connection(self, form):
+        base_url = form.cleaned_data.get(SETTING_BASE_URL) or get_base_url(
+            self.request.event
+        )
+        token = form.cleaned_data.get(SETTING_AUTH_TOKEN, "")
+        client = SusiClient(base_url, token)
         try:
             result = client.verify()
         except SusiError as exc:

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -91,6 +91,12 @@ class InterpretationDashboard(
         base_url = form.cleaned_data.get(SETTING_BASE_URL) or get_base_url(
             self.request.event
         )
+        if not base_url:
+            messages.error(
+                self.request,
+                _("A SUSI server URL is required to test the connection."),
+            )
+            return
         token = form.cleaned_data.get(SETTING_AUTH_TOKEN, "")
         client = SusiClient(base_url, token)
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def dashboard_url(event):
 @pytest.fixture
 def connection_payload():
     return {
-        "base_url": "https://susi.example.com",
-        "auth_token": "jwt-test-token",
-        "is_enabled": "on",
+        "interpretation_base_url": "https://susi.example.com",
+        "interpretation_auth_token": "jwt-test-token",
+        "interpretation_is_enabled": "on",
     }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -91,3 +91,23 @@ def test_save_and_test_warns_when_verify_rejects_token(
     messages = [str(message) for message in get_messages(response.wsgi_request)]
     assert any("connection issue" in message.lower() for message in messages)
     assert any("invalid" in message.lower() for message in messages)
+
+
+@override_settings(SITE_URL="https://testserver")
+def test_save_and_test_without_url_shows_error(
+    monkeypatch, organizer_client, event, dashboard_url
+):
+    calls = []
+
+    class FakeSusiClient:
+        def __init__(self, *args, **kwargs):
+            calls.append(True)
+
+    monkeypatch.setattr("interpretation.views.SusiClient", FakeSusiClient)
+
+    response = organizer_client.post(dashboard_url, {"test": "1"})
+
+    assert response.status_code == 302
+    assert calls == []
+    messages = [str(message) for message in get_messages(response.wsgi_request)]
+    assert any("url" in message.lower() for message in messages)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,10 +1,14 @@
-"""POST tests for the commons interpretation dashboard (save / save-and-test)."""
+"""POST tests for the interpretation dashboard (save / save-and-test)."""
 
 import pytest
 from django.contrib.messages import get_messages
 from django.test import override_settings
 
-from interpretation.models import SusiConnection
+from interpretation.settings import (
+    get_auth_token,
+    get_base_url,
+    is_interpretation_enabled,
+)
 from interpretation.susi import SusiResult
 
 pytestmark = pytest.mark.django_db
@@ -17,10 +21,11 @@ def test_save_persists_connection(
     response = organizer_client.post(dashboard_url, connection_payload)
 
     assert response.status_code == 302
-    connection = SusiConnection.objects.get(event=event)
-    assert connection.base_url == "https://susi.example.com"
-    assert connection.auth_token == "jwt-test-token"
-    assert connection.is_enabled is True
+    event.refresh_from_db()
+    event.settings.flush()
+    assert get_base_url(event) == "https://susi.example.com"
+    assert get_auth_token(event) == "jwt-test-token"
+    assert is_interpretation_enabled(event) is True
 
     messages = [str(message) for message in get_messages(response.wsgi_request)]
     assert any("saved" in message.lower() for message in messages)
@@ -79,8 +84,9 @@ def test_save_and_test_warns_when_verify_rejects_token(
     response = organizer_client.post(dashboard_url, payload)
 
     assert response.status_code == 302
-    connection = SusiConnection.objects.get(event=event)
-    assert connection.auth_token == "jwt-test-token"
+    event.refresh_from_db()
+    event.settings.flush()
+    assert get_auth_token(event) == "jwt-test-token"
 
     messages = [str(message) for message in get_messages(response.wsgi_request)]
     assert any("connection issue" in message.lower() for message in messages)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -10,9 +10,25 @@ from interpretation.settings import (
 PUBLIC_URL = "https://example.com"
 
 
+_SETTING_TYPES = {
+    SETTING_BASE_URL: str,
+    SETTING_AUTH_TOKEN: str,
+    SETTING_IS_ENABLED: bool,
+}
+
+
+class _FakeHierarkey:
+    defaults = {}
+
+    def get_declared_type(self, key):
+        return _SETTING_TYPES.get(key, str)
+
+
 class _FakeSettings:
     def __init__(self, data=None):
         self._data = dict(data or {})
+        self._parent = None
+        self._h = _FakeHierarkey()
 
     def get(self, key, default=None, as_type=str):
         if key not in self._data:
@@ -27,6 +43,9 @@ class _FakeSettings:
 
     def set(self, key, value):
         self._data[key] = value
+
+    def _cache(self):
+        return self._data.keys()
 
 
 class _FakeEvent:

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,46 +1,110 @@
-"""Tests for the SusiConnectionForm validation logic (no database needed)."""
+"""Tests for the InterpretationSettingsForm validation logic."""
 
-from interpretation.forms import SusiConnectionForm
+from interpretation.forms import InterpretationSettingsForm
+from interpretation.settings import (
+    SETTING_AUTH_TOKEN,
+    SETTING_BASE_URL,
+    SETTING_IS_ENABLED,
+)
+
+PUBLIC_URL = "https://example.com"
+
+
+class _FakeSettings:
+    def __init__(self, data=None):
+        self._data = dict(data or {})
+
+    def get(self, key, default=None, as_type=str):
+        if key not in self._data:
+            return default
+        value = self._data[key]
+        if as_type is bool:
+            return bool(value)
+        return as_type(value)
+
+    def freeze(self):
+        return self._data.copy()
+
+    def set(self, key, value):
+        self._data[key] = value
+
+
+class _FakeEvent:
+    def __init__(self, settings=None):
+        self.settings = _FakeSettings(settings)
+
+
+def _form(data, settings=None):
+    return InterpretationSettingsForm(obj=_FakeEvent(settings), data=data)
 
 
 def test_base_url_trailing_slash_is_stripped():
-    form = SusiConnectionForm(
-        data={
-            "base_url": "https://susi.example.com/",
-            "auth_token": "",
-            "is_enabled": False,
+    form = _form(
+        {
+            SETTING_BASE_URL: f"{PUBLIC_URL}/",
+            SETTING_AUTH_TOKEN: "",
+            SETTING_IS_ENABLED: False,
         }
     )
     assert form.is_valid(), form.errors
-    assert form.cleaned_data["base_url"] == "https://susi.example.com"
+    assert form.cleaned_data[SETTING_BASE_URL] == PUBLIC_URL
 
 
 def test_enabling_without_token_is_rejected():
-    form = SusiConnectionForm(
-        data={
-            "base_url": "https://susi.example.com",
-            "auth_token": "",
-            "is_enabled": True,
+    form = _form(
+        {
+            SETTING_BASE_URL: PUBLIC_URL,
+            SETTING_AUTH_TOKEN: "",
+            SETTING_IS_ENABLED: True,
         }
     )
     assert not form.is_valid()
-    assert "auth_token" in form.errors
+    assert SETTING_AUTH_TOKEN in form.errors
 
 
 def test_enabling_with_token_is_accepted():
-    form = SusiConnectionForm(
-        data={
-            "base_url": "https://susi.example.com",
-            "auth_token": "tok",
-            "is_enabled": True,
+    form = _form(
+        {
+            SETTING_BASE_URL: PUBLIC_URL,
+            SETTING_AUTH_TOKEN: "tok",
+            SETTING_IS_ENABLED: True,
         }
     )
     assert form.is_valid(), form.errors
 
 
-def test_base_url_is_required():
-    form = SusiConnectionForm(
-        data={"base_url": "", "auth_token": "", "is_enabled": False}
+def test_enabling_with_existing_token_and_redacted_input_is_accepted():
+    form = _form(
+        {
+            SETTING_BASE_URL: PUBLIC_URL,
+            SETTING_AUTH_TOKEN: "*****",
+            SETTING_IS_ENABLED: True,
+        },
+        settings={SETTING_AUTH_TOKEN: "stored-token"},
     )
-    assert not form.is_valid()
-    assert "base_url" in form.errors
+    assert form.is_valid(), form.errors
+
+
+def test_redacted_token_is_resolved_to_stored_value():
+    form = _form(
+        {
+            SETTING_BASE_URL: PUBLIC_URL,
+            SETTING_AUTH_TOKEN: "*****",
+            SETTING_IS_ENABLED: False,
+        },
+        settings={SETTING_AUTH_TOKEN: "stored-token"},
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data[SETTING_AUTH_TOKEN] == "stored-token"
+
+
+def test_new_token_is_stripped():
+    form = _form(
+        {
+            SETTING_BASE_URL: PUBLIC_URL,
+            SETTING_AUTH_TOKEN: " tok ",
+            SETTING_IS_ENABLED: False,
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data[SETTING_AUTH_TOKEN] == "tok"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,54 @@
+"""Tests for interpretation.settings helpers."""
+
+from interpretation.settings import (
+    SETTING_AUTH_TOKEN,
+    SETTING_BASE_URL,
+    SETTING_IS_ENABLED,
+    get_auth_token,
+    get_base_url,
+    get_susi_client,
+    is_interpretation_enabled,
+)
+
+
+class _FakeSettings:
+    def __init__(self, data=None):
+        self._data = dict(data or {})
+
+    def get(self, key, default=None, as_type=str):
+        if key not in self._data:
+            return default
+        value = self._data[key]
+        if as_type is bool:
+            return bool(value)
+        return as_type(value)
+
+
+class _FakeEvent:
+    def __init__(self, settings=None):
+        self.settings = _FakeSettings(settings)
+
+
+def test_settings_helpers_read_event_values():
+    event = _FakeEvent(
+        {
+            SETTING_BASE_URL: "https://example.com",
+            SETTING_AUTH_TOKEN: "tok",
+            SETTING_IS_ENABLED: True,
+        }
+    )
+    assert get_base_url(event) == "https://example.com"
+    assert get_auth_token(event) == "tok"
+    assert is_interpretation_enabled(event) is True
+
+
+def test_get_susi_client_uses_event_settings():
+    event = _FakeEvent(
+        {
+            SETTING_BASE_URL: "https://example.com",
+            SETTING_AUTH_TOKEN: "tok",
+        }
+    )
+    client = get_susi_client(event)
+    assert client.base_url == "https://example.com/"
+    assert client.auth_token == "tok"

--- a/tests/test_susi_client.py
+++ b/tests/test_susi_client.py
@@ -58,7 +58,7 @@ def test_verify_invalid_token(monkeypatch):
         "request",
         lambda *a, **k: FakeResponse(200, {"authenticated": False}),
     )
-    result = SusiClient("https://susi.example.com", "bad-token").verify()
+    result = SusiClient("https://example.com", "bad-token").verify()
     assert result.ok is False
     assert "invalid" in result.message.lower() or "expired" in result.message.lower()
 
@@ -69,7 +69,7 @@ def test_verify_without_token(monkeypatch):
         "request",
         lambda *a, **k: FakeResponse(200, {"authenticated": False}),
     )
-    result = SusiClient("https://susi.example.com").verify()
+    result = SusiClient("https://example.com").verify()
     assert result.ok is False
     assert "token" in result.message.lower()
 
@@ -80,7 +80,7 @@ def test_verify_server_error(monkeypatch):
         "request",
         lambda *a, **k: FakeResponse(503, {}),
     )
-    result = SusiClient("https://susi.example.com", "tok").verify()
+    result = SusiClient("https://example.com", "tok").verify()
     assert result.ok is False
 
 
@@ -90,7 +90,7 @@ def test_verify_unreachable_raises(monkeypatch):
 
     monkeypatch.setattr(requests, "request", boom)
     with pytest.raises(SusiError):
-        SusiClient("https://susi.example.com", "tok").verify()
+        SusiClient("https://example.com", "tok").verify()
 
 
 def test_login_returns_token_from_cookie(monkeypatch):
@@ -102,7 +102,7 @@ def test_login_returns_token_from_cookie(monkeypatch):
         )
 
     monkeypatch.setattr(requests, "post", fake_post)
-    client = SusiClient("https://susi.example.com")
+    client = SusiClient("https://example.com")
     token = client.login("a@b.c", "secret")
     assert token == "jwt-xyz"
     assert client.auth_token == "jwt-xyz"
@@ -113,7 +113,7 @@ def test_login_rejects_bad_credentials(monkeypatch):
         requests, "post", lambda *a, **k: FakeResponse(401, {"status": "error"})
     )
     with pytest.raises(SusiError):
-        SusiClient("https://susi.example.com").login("a@b.c", "wrong")
+        SusiClient("https://example.com").login("a@b.c", "wrong")
 
 
 def test_create_session_returns_tenant_id(monkeypatch):
@@ -122,7 +122,7 @@ def test_create_session_returns_tenant_id(monkeypatch):
         "request",
         lambda *a, **k: FakeResponse(200, {"tenant_id": "abc123", "source": "url"}),
     )
-    tenant = SusiClient("https://susi.example.com", "tok").create_session("url")
+    tenant = SusiClient("https://example.com", "tok").create_session("url")
     assert tenant == "abc123"
 
 
@@ -133,4 +133,4 @@ def test_create_session_failure_raises(monkeypatch):
         lambda *a, **k: FakeResponse(400, {"error": "bad source"}),
     )
     with pytest.raises(SusiError):
-        SusiClient("https://susi.example.com", "tok").create_session("nope")
+        SusiClient("https://example.com", "tok").create_session("nope")


### PR DESCRIPTION
resolves #45 
## Summary

Moved SUSI connection configuration from the `SusiConnection` model into per-event settings (eventyay's settings backend). This is PR 3 of 5 in the milestone-1 stack.

**Depends on:** #40 (`m1-susi-client`) and #41 (`m1-models-dashboard-scaffold`). Merge them first.

## What changed

- Added `interpretation/settings.py` helpers for base URL, auth token, email/name, enabled flag, and `SusiClient` factory
- Registered interpretation settings via `settings_hierarkey` in `signals.py`
- Removed the `SusiConnection` model; dropped the `RoomInterpretation.connection` FK
- Added migration `0002_move_connection_to_event_settings`, which copies existing `SusiConnection` rows into event settings before deleting the model
- Updated dashboard form/views to read/write event settings instead of the model
- Preserved the auth token on save/test when the form submits a redacted placeholder (an empty token field no longer wipes the stored token)
- Extended tests for settings helpers, forms, and `SusiClient`

<img width="1020" height="651" alt="image" src="https://github.com/user-attachments/assets/3c9eb547-31b6-4fd5-a9c5-7f7326069d00" />

## Why

Eventyay already stores per-event plugin config in the settings backend. Using it for SUSI credentials avoids a separate connection table and matches how other plugins persist event-level secrets.

## Test plan

- [ ] `pytest` / `ruff check .` pass
- [ ] Fresh install: run migrations (0001 → 0002), confirm no `SusiConnection` table
- [ ] Upgrade path: with existing `SusiConnection` data, migration copies values into event settings
- [ ] Commons dashboard: save base URL + token, reload page — settings persist
- [ ] Save/test with redacted token placeholder — stored token unchanged
- [ ] Disconnect clears email/name/token from event settings

## Stack

| PR | Branch | Status |
|----|--------|--------|
| 1 | `m1-susi-client` | #40 |
| 2 | `m1-models-dashboard-scaffold` | #41 |
| 3 | `m1-event-settings` | this PR |
| 4 | `m1-email-password-connect` | — |
| 5 | `m1-dashboard-redesign` | — |

Merge order: 1 → 2 → 3 → 4 → 5. 