### PR TITLE
Add email/password login to connect events to SUSI

### DIFF
--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -119,6 +119,20 @@ class InterpretationSettingsForm(SettingsForm):
                 )
         return cleaned
 
+    _TRANSIENT_FIELDS = frozenset({"susi_connect_password", "susi_connect_email"})
+
+    def save(self):
+        # ponytail: login fields are POST-only; never write them to event.settings.
+        removed = {
+            name: self.fields.pop(name)
+            for name in self._TRANSIENT_FIELDS
+            if name in self.fields
+        }
+        try:
+            return super().save()
+        finally:
+            self.fields.update(removed)
+
     def run_connect_action(self, request):
         base_url = self.cleaned_data.get(SETTING_BASE_URL) or get_base_url(self.obj)
         email = (self.cleaned_data.get("susi_connect_email") or "").strip()

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -1,52 +1,83 @@
 from django import forms
+from django.contrib import messages
 from django.utils.translation import gettext_lazy as _
-from eventyay.base.forms import SECRET_REDACTED, SecretKeySettingsField, SettingsForm
+from eventyay.base.forms import SettingsForm
 
 from .settings import (
-    SETTING_AUTH_TOKEN,
     SETTING_BASE_URL,
     SETTING_IS_ENABLED,
+    disconnect_susi,
+    get_auth_token,
+    get_base_url,
+    get_susi_email,
+    get_susi_name,
+    save_susi_connection,
 )
+from .susi import SusiClient, SusiError
+
+CONNECT_POST_KEY = "interpretation_connect"
+DISCONNECT_POST_KEY = "interpretation_disconnect"
+TEST_POST_KEY = "interpretation_test_connection"
 
 
 class InterpretationSettingsForm(SettingsForm):
-    """Per-event SUSI server connection settings."""
+    """Commons dashboard form: connect to SUSI with email/password."""
+
+    template = "interpretation/susi_connection_form.html"
+    connect_action_post_key = CONNECT_POST_KEY
+    disconnect_action_post_key = DISCONNECT_POST_KEY
+    test_action_post_key = TEST_POST_KEY
 
     interpretation_base_url = forms.URLField(
         label=_("SUSI server URL"),
         help_text=_(
-            "Base URL of the SUSI Translator Flask server, "
-            "e.g. https://susi.example.com"
+            "Base URL of the SUSI Translator server, e.g. https://susi.example.com"
         ),
         required=False,
         widget=forms.URLInput(attrs={"placeholder": "https://susi.example.com"}),
-    )
-    interpretation_auth_token = SecretKeySettingsField(
-        label=_("Authentication token"),
-        help_text=_(
-            "JWT or long-lived token used to authenticate against the SUSI "
-            "server. Sent as a Bearer token; never exposed to attendees."
-        ),
-        required=False,
     )
     interpretation_is_enabled = forms.BooleanField(
         label=_("Enable interpretation"),
         help_text=_("Master switch for SUSI interpretation on this event."),
         required=False,
     )
+    susi_connect_email = forms.EmailField(
+        label=_("SUSI account email"),
+        required=False,
+    )
+    susi_connect_password = forms.CharField(
+        label=_("Password"),
+        required=False,
+        widget=forms.PasswordInput(render_value=False),
+    )
 
-    def _stored_auth_token(self) -> str:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for name in (
+            "interpretation_base_url",
+            "susi_connect_email",
+            "susi_connect_password",
+        ):
+            self.fields[name].widget.attrs.setdefault("class", "form-control")
+        if self.obj and get_susi_email(self.obj):
+            self.fields["susi_connect_email"].initial = get_susi_email(self.obj)
+
+    @property
+    def is_connected(self) -> bool:
+        return bool(self.obj and get_auth_token(self.obj))
+
+    @property
+    def connected_label(self) -> str:
         if not self.obj:
             return ""
-        return self.obj.settings.get(SETTING_AUTH_TOKEN, default="", as_type=str)
+        name = get_susi_name(self.obj)
+        email = get_susi_email(self.obj)
+        if name and email:
+            return f"{name} ({email})"
+        return email or name
 
-    def clean_interpretation_auth_token(self):
-        token = (self.cleaned_data.get(SETTING_AUTH_TOKEN) or "").strip()
-        if token == SECRET_REDACTED:
-            token = (
-                self._stored_auth_token() or self.initial.get(SETTING_AUTH_TOKEN) or ""
-            ).strip()
-        return token
+    def _connecting(self) -> bool:
+        return CONNECT_POST_KEY in self.data
 
     def clean_interpretation_base_url(self):
         url = (self.cleaned_data.get("interpretation_base_url") or "").strip()
@@ -54,21 +85,101 @@ class InterpretationSettingsForm(SettingsForm):
 
     def clean(self):
         cleaned = super().clean()
+        base_url = cleaned.get(SETTING_BASE_URL)
+        email = (cleaned.get("susi_connect_email") or "").strip()
+        password = cleaned.get("susi_connect_password") or ""
+
+        if self._connecting():
+            if not base_url:
+                self.add_error(
+                    SETTING_BASE_URL,
+                    _("A SUSI server URL is required to connect."),
+                )
+            if not email:
+                self.add_error(
+                    "susi_connect_email",
+                    _("Email is required to connect."),
+                )
+            if not password:
+                self.add_error(
+                    "susi_connect_password",
+                    _("Password is required to connect."),
+                )
+
         if cleaned.get(SETTING_IS_ENABLED):
-            if not cleaned.get(SETTING_BASE_URL):
+            if not base_url:
                 self.add_error(
                     SETTING_BASE_URL,
                     _("A SUSI server URL is required to enable interpretation."),
                 )
-            token = cleaned.get(SETTING_AUTH_TOKEN)
-            if not token:
+            if not get_auth_token(self.obj) and not self._connecting():
                 self.add_error(
-                    SETTING_AUTH_TOKEN,
-                    _("An authentication token is required to enable interpretation."),
+                    SETTING_IS_ENABLED,
+                    _("Connect to SUSI before enabling interpretation."),
                 )
         return cleaned
 
-    def save(self):
-        if self.cleaned_data.get(SETTING_AUTH_TOKEN) == SECRET_REDACTED:
-            self.cleaned_data[SETTING_AUTH_TOKEN] = self._stored_auth_token()
-        return super().save()
+    def run_connect_action(self, request):
+        base_url = self.cleaned_data.get(SETTING_BASE_URL) or get_base_url(self.obj)
+        email = (self.cleaned_data.get("susi_connect_email") or "").strip()
+        password = self.cleaned_data.get("susi_connect_password") or ""
+        client = SusiClient(base_url)
+        try:
+            result = client.login(email, password)
+        except SusiError as exc:
+            messages.error(
+                request,
+                _("Could not connect to SUSI: %(error)s") % {"error": str(exc)},
+            )
+            return
+        save_susi_connection(
+            self.obj,
+            token=result.token,
+            email=result.email,
+            name=result.name,
+        )
+        label = result.name or result.email
+        if result.name and result.email:
+            label = f"{result.name} ({result.email})"
+        messages.success(
+            request,
+            _("Connected to SUSI as %(account)s.") % {"account": label},
+        )
+
+    def run_disconnect_action(self, request):
+        disconnect_susi(self.obj)
+        messages.success(request, _("Disconnected from SUSI."))
+
+    def run_test_action(self, request):
+        base_url = self.cleaned_data.get(SETTING_BASE_URL) or get_base_url(self.obj)
+        if not base_url:
+            messages.error(
+                request,
+                _("A SUSI server URL is required to test the connection."),
+            )
+            return
+        token = get_auth_token(self.obj)
+        if not token:
+            messages.error(
+                request,
+                _("Connect to SUSI before testing the connection."),
+            )
+            return
+        client = SusiClient(base_url, token)
+        try:
+            result = client.verify()
+        except SusiError as exc:
+            messages.error(
+                request, _("Connection failed: %(error)s") % {"error": str(exc)}
+            )
+            return
+        if result.ok:
+            messages.success(
+                request,
+                _("Connection successful: %(message)s") % {"message": result.message},
+            )
+        else:
+            messages.warning(
+                request,
+                _("Connection issue: %(message)s") % {"message": result.message},
+            )

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -121,17 +121,20 @@ class InterpretationSettingsForm(SettingsForm):
 
     _TRANSIENT_FIELDS = frozenset({"susi_connect_password", "susi_connect_email"})
 
-    def save(self):
-        # ponytail: login fields are POST-only; never write them to event.settings.
-        removed = {
-            name: self.fields.pop(name)
-            for name in self._TRANSIENT_FIELDS
-            if name in self.fields
-        }
+    def _save_excluding_fields(self, excluded: frozenset):
+        removed = {name: self.fields.pop(name) for name in excluded if name in self.fields}
         try:
             return super().save()
         finally:
             self.fields.update(removed)
+
+    def save(self):
+        # ponytail: login fields are POST-only; never write them to event.settings.
+        return self._save_excluding_fields(self._TRANSIENT_FIELDS)
+
+    def save_pending_connect(self):
+        """Persist URL before login; defer is_enabled until connect succeeds."""
+        return self._save_excluding_fields(self._TRANSIENT_FIELDS | {SETTING_IS_ENABLED})
 
     def run_connect_action(self, request):
         base_url = self.cleaned_data.get(SETTING_BASE_URL) or get_base_url(self.obj)
@@ -151,6 +154,9 @@ class InterpretationSettingsForm(SettingsForm):
             token=result.token,
             email=result.email,
             name=result.name,
+        )
+        self.obj.settings.set(
+            SETTING_IS_ENABLED, bool(self.cleaned_data.get(SETTING_IS_ENABLED))
         )
         label = result.name or result.email
         if result.name and result.email:

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -122,7 +122,9 @@ class InterpretationSettingsForm(SettingsForm):
     _TRANSIENT_FIELDS = frozenset({"susi_connect_password", "susi_connect_email"})
 
     def _save_excluding_fields(self, excluded: frozenset):
-        removed = {name: self.fields.pop(name) for name in excluded if name in self.fields}
+        removed = {
+            name: self.fields.pop(name) for name in excluded if name in self.fields
+        }
         try:
             return super().save()
         finally:
@@ -134,7 +136,8 @@ class InterpretationSettingsForm(SettingsForm):
 
     def save_pending_connect(self):
         """Persist URL before login; defer is_enabled until connect succeeds."""
-        return self._save_excluding_fields(self._TRANSIENT_FIELDS | {SETTING_IS_ENABLED})
+        excluded = self._TRANSIENT_FIELDS | {SETTING_IS_ENABLED}
+        return self._save_excluding_fields(excluded)
 
     def run_connect_action(self, request):
         base_url = self.cleaned_data.get(SETTING_BASE_URL) or get_base_url(self.obj)

--- a/interpretation/settings.py
+++ b/interpretation/settings.py
@@ -8,6 +8,8 @@ from .susi import SusiClient
 
 SETTING_BASE_URL = "interpretation_base_url"
 SETTING_AUTH_TOKEN = "interpretation_auth_token"
+SETTING_SUSI_EMAIL = "interpretation_susi_email"
+SETTING_SUSI_NAME = "interpretation_susi_name"
 SETTING_IS_ENABLED = "interpretation_is_enabled"
 
 
@@ -19,8 +21,34 @@ def get_auth_token(event: Event) -> str:
     return event.settings.get(SETTING_AUTH_TOKEN, default="", as_type=str)
 
 
+def get_susi_email(event: Event) -> str:
+    return event.settings.get(SETTING_SUSI_EMAIL, default="", as_type=str)
+
+
+def get_susi_name(event: Event) -> str:
+    return event.settings.get(SETTING_SUSI_NAME, default="", as_type=str)
+
+
 def is_interpretation_enabled(event: Event) -> bool:
     return event.settings.get(SETTING_IS_ENABLED, default=False, as_type=bool)
+
+
+def is_susi_configured(event: Event) -> bool:
+    return bool(get_base_url(event) and get_auth_token(event))
+
+
+def save_susi_connection(
+    event: Event, *, token: str, email: str = "", name: str = ""
+) -> None:
+    event.settings.set(SETTING_AUTH_TOKEN, token)
+    event.settings.set(SETTING_SUSI_EMAIL, email)
+    event.settings.set(SETTING_SUSI_NAME, name)
+
+
+def disconnect_susi(event: Event) -> None:
+    event.settings.set(SETTING_AUTH_TOKEN, "")
+    event.settings.set(SETTING_SUSI_EMAIL, "")
+    event.settings.set(SETTING_SUSI_NAME, "")
 
 
 def get_susi_client(event: Event) -> SusiClient:

--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -8,10 +8,16 @@ from .settings import (
     SETTING_AUTH_TOKEN,
     SETTING_BASE_URL,
     SETTING_IS_ENABLED,
+    SETTING_SUSI_EMAIL,
+    SETTING_SUSI_NAME,
 )
+
+PLUGIN_MODULE = "interpretation"
 
 settings_hierarkey.add_default(SETTING_BASE_URL, "", str)
 settings_hierarkey.add_default(SETTING_AUTH_TOKEN, "", str)
+settings_hierarkey.add_default(SETTING_SUSI_EMAIL, "", str)
+settings_hierarkey.add_default(SETTING_SUSI_NAME, "", str)
 settings_hierarkey.add_default(SETTING_IS_ENABLED, False, bool)
 
 

--- a/interpretation/susi.py
+++ b/interpretation/susi.py
@@ -16,9 +16,10 @@ Relevant SUSI endpoints used here:
 
 from __future__ import annotations
 
-import requests
 from dataclasses import dataclass
 from urllib.parse import urljoin
+
+import requests
 
 DEFAULT_TIMEOUT = 10
 

--- a/interpretation/susi.py
+++ b/interpretation/susi.py
@@ -1,9 +1,24 @@
+"""Thin HTTP client for the SUSI Translator Flask API.
+
+The SUSI server is a separate Flask service (fossasia/susi_translator). It uses
+JWT auth (flask-jwt-extended) with tokens accepted in either cookies or the
+``Authorization`` header. This client always authenticates via the header with a
+Bearer token to avoid cookie CSRF handling.
+
+Relevant SUSI endpoints used here:
+    GET  /auth/api/status     -> {"authenticated": bool, "email", "name"}
+    POST /auth/api/login      -> sets JWT cookie, body {status,email,name}
+    POST /session             -> {"tenant_id", "source"}
+    POST /api/v1/translate/configure
+    GET  /api/v1/translate/status/<tenant_id>
+    POST /stop_event/<tenant_id>
+"""
+
 from __future__ import annotations
 
+import requests
 from dataclasses import dataclass
 from urllib.parse import urljoin
-
-import requests
 
 DEFAULT_TIMEOUT = 10
 
@@ -20,6 +35,13 @@ class SusiResult:
     message: str = ""
 
 
+@dataclass
+class SusiLoginResult:
+    token: str
+    email: str
+    name: str
+
+
 class SusiClient:
     """Minimal client for talking to a SUSI Translator server."""
 
@@ -33,7 +55,7 @@ class SusiClient:
         self.auth_token = auth_token or ""
         self.timeout = timeout
 
-    # internals
+    # -- internals -------------------------------------------------------
 
     def _url(self, path: str) -> str:
         return urljoin(self.base_url, path.lstrip("/"))
@@ -63,10 +85,14 @@ class SusiClient:
             data=data if isinstance(data, dict) else {"result": data},
         )
 
-    # auth / health
+    # -- auth / health ---------------------------------------------------
 
     def verify(self) -> SusiResult:
-        """Check reachability and token validity via ``/auth/api/status``."""
+        """Check reachability and token validity via ``/auth/api/status``.
+
+        Returns a :class:`SusiResult` with ``ok=True`` only when the server is
+        reachable AND the configured token authenticates successfully.
+        """
         result = self._request("GET", "/auth/api/status")
         if result.status_code is None or result.status_code >= 500:
             result.ok = False
@@ -85,8 +111,12 @@ class SusiClient:
             result.message = "Server reachable but token is invalid or expired."
         return result
 
-    def login(self, email: str, password: str) -> str:
-        """Authenticate with email/password and return the JWT access token."""
+    def login(self, email: str, password: str) -> SusiLoginResult:
+        """Authenticate with email/password and return the JWT access token.
+
+        SUSI sets the token as the ``access_token_cookie``; we read it from the
+        response cookies so it can be stored and reused as a Bearer token.
+        """
         url = self._url("/auth/api/login")
         try:
             resp = requests.post(
@@ -100,13 +130,24 @@ class SusiClient:
         if not resp.ok:
             raise SusiError("Invalid SUSI credentials or server rejected login.")
 
+        try:
+            data = resp.json() if resp.content else {}
+        except ValueError:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+
         token = resp.cookies.get("access_token_cookie")
         if not token:
             raise SusiError("Login succeeded but no access token was returned.")
         self.auth_token = token
-        return token
+        return SusiLoginResult(
+            token=token,
+            email=(data.get("email") or email).strip(),
+            name=(data.get("name") or "").strip(),
+        )
 
-    # session lifecycle (used by later milestones)
+    # -- session lifecycle (used by later milestones) -------------------
 
     def create_session(self, source: str = "url") -> str:
         """Mint a tenant/session ID for a given audio source."""

--- a/interpretation/templates/interpretation/dashboard.html
+++ b/interpretation/templates/interpretation/dashboard.html
@@ -1,38 +1,14 @@
 {% extends "eventyay_common/event/base.html" %}
-{% load i18n %}
-{% load bootstrap3 %}
+{% load i18n bootstrap3 %}
 {% block title %}{% trans "Interpretation" %}{% endblock %}
 {% block content %}
     <h1>{% trans "Interpretation" %}</h1>
 
     <p class="text-muted">
-        {% blocktrans trimmed %}
-            Connect this event to a SUSI Translator server to provide live
-            transcription and translation for your rooms.
+        {% blocktrans trimmed with event_name=event.name %}
+            Live transcription and translation for {{ event_name }} via SUSI Translator.
         {% endblocktrans %}
     </p>
-
-    <form action="" method="post" class="form-horizontal">
-        {% csrf_token %}
-        {% bootstrap_form_errors form %}
-        <fieldset>
-            <legend>{% trans "SUSI server connection" %}</legend>
-            {% bootstrap_field form.interpretation_base_url layout='horizontal' %}
-            {% bootstrap_field form.interpretation_auth_token layout='horizontal' %}
-            {% bootstrap_field form.interpretation_is_enabled layout='horizontal' %}
-        </fieldset>
-
-        <div class="form-group">
-            <div class="col-md-9 col-md-offset-3">
-                <button type="submit" class="btn btn-primary btn-save">
-                    {% trans "Save" %}
-                </button>
-                <button type="submit" name="test" value="1" class="btn btn-default">
-                    {% trans "Save and test connection" %}
-                </button>
-            </div>
-        </div>
-    </form>
 
     <div class="panel panel-default">
         <div class="panel-heading">
@@ -40,6 +16,10 @@
         </div>
         <table class="table">
             <tbody>
+                <tr>
+                    <th>{% trans "Event" %}</th>
+                    <td>{{ event.name }}</td>
+                </tr>
                 <tr>
                     <th>{% trans "Plugin enabled for this event" %}</th>
                     <td>
@@ -60,7 +40,39 @@
                         {% endif %}
                     </td>
                 </tr>
+                <tr>
+                    <th>{% trans "SUSI server connected" %}</th>
+                    <td>
+                        {% if susi_configured %}
+                            <span class="label label-success">{% trans "Yes" %}</span>
+                            {% if susi_server_host %}
+                                <span class="text-muted">({{ susi_server_host }})</span>
+                            {% endif %}
+                        {% else %}
+                            <span class="label label-warning">{% trans "No" %}</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% if susi_account %}
+                <tr>
+                    <th>{% trans "SUSI account" %}</th>
+                    <td>{{ susi_account }}</td>
+                </tr>
+                {% endif %}
             </tbody>
         </table>
+    </div>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% trans "SUSI connection" %}</h3>
+        </div>
+        <div class="panel-body">
+            <form action="" method="post" class="form-horizontal">
+                {% csrf_token %}
+                {% bootstrap_form_errors form %}
+                {% include form.template with form=form %}
+            </form>
+        </div>
     </div>
 {% endblock %}

--- a/interpretation/templates/interpretation/susi_connection_form.html
+++ b/interpretation/templates/interpretation/susi_connection_form.html
@@ -1,0 +1,91 @@
+{% load i18n bootstrap3 %}
+<div class="interpretation-susi-connection">
+    <p class="text-muted interpretation-susi-intro">
+        {% blocktrans trimmed %}
+            Sign in with a SUSI Translator service account for this event.
+        {% endblocktrans %}
+    </p>
+
+    {% bootstrap_field form.interpretation_base_url layout="horizontal" %}
+
+    {% if form.is_connected %}
+        <div class="form-group">
+            <div class="col-md-offset-3 col-md-9">
+                <div class="alert alert-success interpretation-susi-alert">
+                    {% blocktrans trimmed with account=form.connected_label %}
+                        Connected to SUSI as {{ account }}.
+                    {% endblocktrans %}
+                </div>
+                <div class="interpretation-susi-actions">
+                    <button type="submit" name="interpretation_disconnect" value="1" class="btn btn-warning">
+                        {% trans "Disconnect" %}
+                    </button>
+                    <button type="submit" name="interpretation_test_connection" value="1" class="btn btn-default">
+                        {% trans "Test connection" %}
+                    </button>
+                </div>
+                <p class="text-muted interpretation-susi-hint">
+                    {% trans "Sign in again to replace the stored session (for example after token expiry)." %}
+                </p>
+            </div>
+        </div>
+    {% endif %}
+
+    {% bootstrap_field form.susi_connect_email layout="horizontal" show_help=False %}
+    {% bootstrap_field form.susi_connect_password layout="horizontal" show_help=False %}
+
+    <div class="form-group">
+        <div class="col-md-offset-3 col-md-9">
+            <button type="submit" name="interpretation_connect" value="1" class="btn btn-primary">
+                {% if form.is_connected %}
+                    {% trans "Reconnect" %}
+                {% else %}
+                    {% trans "Connect to SUSI" %}
+                {% endif %}
+            </button>
+        </div>
+    </div>
+
+    <hr class="interpretation-susi-divider">
+
+    {% bootstrap_field form.interpretation_is_enabled layout="horizontal" %}
+
+    <div class="form-group submit-group">
+        <div class="col-md-offset-3 col-md-9">
+            <button type="submit" class="btn btn-primary btn-save">
+                {% trans "Save" %}
+            </button>
+        </div>
+    </div>
+</div>
+<style>
+    .interpretation-susi-connection .interpretation-susi-intro {
+        margin: 0 0 1.25rem 0;
+        padding-left: 25%;
+    }
+    @media (max-width: 991px) {
+        .interpretation-susi-connection .interpretation-susi-intro {
+            padding-left: 0;
+        }
+    }
+    .interpretation-susi-connection .interpretation-susi-alert {
+        margin-bottom: 0.75rem;
+    }
+    .interpretation-susi-connection .interpretation-susi-actions .btn {
+        margin-right: 0.5rem;
+        margin-bottom: 0.5rem;
+    }
+    .interpretation-susi-connection .interpretation-susi-hint {
+        margin: 0.75rem 0 0;
+    }
+    .interpretation-susi-connection .interpretation-susi-divider {
+        margin: 1.5rem 0 1.25rem;
+        border-color: #e5e5e5;
+    }
+    .interpretation-susi-connection .form-group {
+        margin-bottom: 1rem;
+    }
+    .interpretation-susi-connection .help-block {
+        margin-bottom: 0;
+    }
+</style>

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -9,8 +9,8 @@ from eventyay.control.views.event import EventSettingsViewMixin
 from .forms import (
     CONNECT_POST_KEY,
     DISCONNECT_POST_KEY,
-    InterpretationSettingsForm,
     TEST_POST_KEY,
+    InterpretationSettingsForm,
 )
 from .settings import (
     get_base_url,

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -79,8 +79,7 @@ class InterpretationDashboard(
             return redirect(self.get_success_url())
         if CONNECT_POST_KEY in request.POST:
             if form.is_valid():
-                if form.has_changed():
-                    form.save()
+                form.save_pending_connect()
                 form.run_connect_action(request)
             else:
                 return self.form_invalid(form)

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -1,19 +1,24 @@
 from django.contrib import messages
-from django.db import transaction
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from eventyay.base.models import Event
-from eventyay.control.views.event import EventSettingsFormView, EventSettingsViewMixin
+from django.views.generic import FormView
+from eventyay.control.permissions import EventPermissionRequiredMixin
+from eventyay.control.views.event import EventSettingsViewMixin
 
-from .forms import InterpretationSettingsForm
-from .settings import (
-    SETTING_AUTH_TOKEN,
-    SETTING_BASE_URL,
-    get_base_url,
-    is_interpretation_enabled,
+from .forms import (
+    CONNECT_POST_KEY,
+    DISCONNECT_POST_KEY,
+    InterpretationSettingsForm,
+    TEST_POST_KEY,
 )
-from .susi import SusiClient, SusiError
+from .settings import (
+    get_base_url,
+    get_susi_email,
+    get_susi_name,
+    is_interpretation_enabled,
+    is_susi_configured,
+)
 
 PLUGIN_MODULE = "interpretation"
 
@@ -32,14 +37,20 @@ class InterpretationEnabledMixin:
 class InterpretationDashboard(
     InterpretationEnabledMixin,
     EventSettingsViewMixin,
-    EventSettingsFormView,
+    EventPermissionRequiredMixin,
+    FormView,
 ):
-    """Configure the per-event SUSI connection and test connectivity."""
+    """Interpretation overview and SUSI connection settings for organizers."""
 
-    model = Event
+    form_class = InterpretationSettingsForm
     template_name = "interpretation/dashboard.html"
     permission = "can_change_event_settings"
-    form_class = InterpretationSettingsForm
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["obj"] = self.request.event
+        kwargs["prefix"] = "interpretation"
+        return kwargs
 
     def get_success_url(self):
         return reverse(
@@ -54,65 +65,56 @@ class InterpretationDashboard(
         ctx = super().get_context_data(**kwargs)
         event = self.request.event
         ctx["event"] = event
-        ctx["plugin_module"] = PLUGIN_MODULE
         ctx["plugin_enabled"] = PLUGIN_MODULE in event.get_plugins()
         ctx["interpretation_enabled"] = is_interpretation_enabled(event)
+        ctx["susi_configured"] = is_susi_configured(event)
+        ctx["susi_server_host"] = _susi_host(get_base_url(event))
+        ctx["susi_account"] = _susi_account_label(event)
         return ctx
 
-    @transaction.atomic
     def post(self, request, *args, **kwargs):
         form = self.get_form()
+        if DISCONNECT_POST_KEY in request.POST:
+            form.run_disconnect_action(request)
+            return redirect(self.get_success_url())
+        if CONNECT_POST_KEY in request.POST:
+            if form.is_valid():
+                if form.has_changed():
+                    form.save()
+                form.run_connect_action(request)
+            else:
+                return self.form_invalid(form)
+            return redirect(self.get_success_url())
+        if TEST_POST_KEY in request.POST:
+            if form.is_valid():
+                if form.has_changed():
+                    form.save()
+                form.run_test_action(request)
+            else:
+                return self.form_invalid(form)
+            return redirect(self.get_success_url())
         if form.is_valid():
             form.save()
-            self._save_decoupled(form)
-            if form.has_changed():
-                request.event.log_action(
-                    "eventyay.event.settings",
-                    user=request.user,
-                    data={
-                        k: form.cleaned_data.get(k)
-                        for k in form.changed_data
-                        if k != "interpretation_auth_token"
-                    },
-                )
-            if "test" in request.POST:
-                self._test_connection(form)
-            else:
-                messages.success(request, _("Connection settings saved."))
+            messages.success(request, _("Your changes have been saved."))
             return redirect(self.get_success_url())
-
         messages.error(
             request,
-            _("Please correct the errors below before saving."),
+            _("We could not save your changes. See below for details."),
         )
-        return self.render_to_response(self.get_context_data(form=form))
+        return self.form_invalid(form)
 
-    def _test_connection(self, form):
-        base_url = form.cleaned_data.get(SETTING_BASE_URL) or get_base_url(
-            self.request.event
-        )
-        if not base_url:
-            messages.error(
-                self.request,
-                _("A SUSI server URL is required to test the connection."),
-            )
-            return
-        token = form.cleaned_data.get(SETTING_AUTH_TOKEN, "")
-        client = SusiClient(base_url, token)
-        try:
-            result = client.verify()
-        except SusiError as exc:
-            messages.error(
-                self.request, _("Connection failed: %(error)s") % {"error": str(exc)}
-            )
-            return
-        if result.ok:
-            messages.success(
-                self.request,
-                _("Connection successful: %(message)s") % {"message": result.message},
-            )
-        else:
-            messages.warning(
-                self.request,
-                _("Connection issue: %(message)s") % {"message": result.message},
-            )
+
+def _susi_account_label(event) -> str:
+    name = get_susi_name(event)
+    email = get_susi_email(event)
+    if name and email:
+        return f"{name} ({email})"
+    return email or name
+
+
+def _susi_host(base_url: str) -> str:
+    if not base_url:
+        return ""
+    from urllib.parse import urlparse
+
+    return urlparse(base_url).netloc or base_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,9 +84,15 @@ def dashboard_url(event):
 
 
 @pytest.fixture
+def connected_event(event):
+    event.settings.set("interpretation_auth_token", "jwt-test-token")
+    event.settings.set("interpretation_susi_email", "susi@example.com")
+    return event
+
+
+@pytest.fixture
 def connection_payload():
     return {
-        "interpretation_base_url": "https://susi.example.com",
-        "interpretation_auth_token": "jwt-test-token",
-        "interpretation_is_enabled": "on",
+        "interpretation-interpretation_base_url": "https://susi.example.com",
+        "interpretation-interpretation_is_enabled": "on",
     }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4,6 +4,7 @@ import pytest
 from django.contrib.messages import get_messages
 from django.test import override_settings
 
+from interpretation.forms import TEST_POST_KEY
 from interpretation.settings import (
     get_auth_token,
     get_base_url,
@@ -16,16 +17,16 @@ pytestmark = pytest.mark.django_db
 
 @override_settings(SITE_URL="https://testserver")
 def test_save_persists_connection(
-    organizer_client, event, dashboard_url, connection_payload
+    organizer_client, connected_event, dashboard_url, connection_payload
 ):
     response = organizer_client.post(dashboard_url, connection_payload)
 
     assert response.status_code == 302
-    event.refresh_from_db()
-    event.settings.flush()
-    assert get_base_url(event) == "https://susi.example.com"
-    assert get_auth_token(event) == "jwt-test-token"
-    assert is_interpretation_enabled(event) is True
+    connected_event.refresh_from_db()
+    connected_event.settings.flush()
+    assert get_base_url(connected_event) == "https://susi.example.com"
+    assert get_auth_token(connected_event) == "jwt-test-token"
+    assert is_interpretation_enabled(connected_event) is True
 
     messages = [str(message) for message in get_messages(response.wsgi_request)]
     assert any("saved" in message.lower() for message in messages)
@@ -33,7 +34,7 @@ def test_save_persists_connection(
 
 @override_settings(SITE_URL="https://testserver")
 def test_save_and_test_calls_verify_with_saved_token(
-    monkeypatch, organizer_client, event, dashboard_url, connection_payload
+    monkeypatch, organizer_client, connected_event, dashboard_url, connection_payload
 ):
     calls = []
 
@@ -49,9 +50,9 @@ def test_save_and_test_calls_verify_with_saved_token(
                 message="Connected and authenticated.",
             )
 
-    monkeypatch.setattr("interpretation.views.SusiClient", FakeSusiClient)
+    monkeypatch.setattr("interpretation.forms.SusiClient", FakeSusiClient)
 
-    payload = {**connection_payload, "test": "1"}
+    payload = {**connection_payload, TEST_POST_KEY: "1"}
     response = organizer_client.post(dashboard_url, payload)
 
     assert response.status_code == 302
@@ -63,7 +64,7 @@ def test_save_and_test_calls_verify_with_saved_token(
 
 @override_settings(SITE_URL="https://testserver")
 def test_save_and_test_warns_when_verify_rejects_token(
-    monkeypatch, organizer_client, event, dashboard_url, connection_payload
+    monkeypatch, organizer_client, connected_event, dashboard_url, connection_payload
 ):
     class FakeSusiClient:
         def __init__(self, base_url, auth_token="", timeout=10):
@@ -78,15 +79,15 @@ def test_save_and_test_warns_when_verify_rejects_token(
                 message="Server reachable but token is invalid or expired.",
             )
 
-    monkeypatch.setattr("interpretation.views.SusiClient", FakeSusiClient)
+    monkeypatch.setattr("interpretation.forms.SusiClient", FakeSusiClient)
 
-    payload = {**connection_payload, "test": "1"}
+    payload = {**connection_payload, TEST_POST_KEY: "1"}
     response = organizer_client.post(dashboard_url, payload)
 
     assert response.status_code == 302
-    event.refresh_from_db()
-    event.settings.flush()
-    assert get_auth_token(event) == "jwt-test-token"
+    connected_event.refresh_from_db()
+    connected_event.settings.flush()
+    assert get_auth_token(connected_event) == "jwt-test-token"
 
     messages = [str(message) for message in get_messages(response.wsgi_request)]
     assert any("connection issue" in message.lower() for message in messages)
@@ -94,8 +95,8 @@ def test_save_and_test_warns_when_verify_rejects_token(
 
 
 @override_settings(SITE_URL="https://testserver")
-def test_save_and_test_without_url_shows_error(
-    monkeypatch, organizer_client, event, dashboard_url
+def test_test_connection_without_url_shows_error(
+    monkeypatch, organizer_client, connected_event, dashboard_url
 ):
     calls = []
 
@@ -103,9 +104,9 @@ def test_save_and_test_without_url_shows_error(
         def __init__(self, *args, **kwargs):
             calls.append(True)
 
-    monkeypatch.setattr("interpretation.views.SusiClient", FakeSusiClient)
+    monkeypatch.setattr("interpretation.forms.SusiClient", FakeSusiClient)
 
-    response = organizer_client.post(dashboard_url, {"test": "1"})
+    response = organizer_client.post(dashboard_url, {TEST_POST_KEY: "1"})
 
     assert response.status_code == 302
     assert calls == []

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,10 +1,11 @@
-"""Tests for the InterpretationSettingsForm validation logic."""
+"""Tests for InterpretationSettingsForm validation and connect flow."""
 
-from interpretation.forms import InterpretationSettingsForm
+from interpretation.forms import CONNECT_POST_KEY, InterpretationSettingsForm
 from interpretation.settings import (
     SETTING_AUTH_TOKEN,
     SETTING_BASE_URL,
     SETTING_IS_ENABLED,
+    SETTING_SUSI_EMAIL,
 )
 
 PUBLIC_URL = "https://example.com"
@@ -53,15 +54,22 @@ class _FakeEvent:
         self.settings = _FakeSettings(settings)
 
 
-def _form(data, settings=None):
-    return InterpretationSettingsForm(obj=_FakeEvent(settings), data=data)
+def _form(data, settings=None, prefix="interpretation"):
+    post = {}
+    for key, value in data.items():
+        if key == CONNECT_POST_KEY:
+            post[key] = value
+        else:
+            post[f"{prefix}-{key}"] = value
+    return InterpretationSettingsForm(
+        obj=_FakeEvent(settings), data=post, prefix=prefix
+    )
 
 
 def test_base_url_trailing_slash_is_stripped():
     form = _form(
         {
             SETTING_BASE_URL: f"{PUBLIC_URL}/",
-            SETTING_AUTH_TOKEN: "",
             SETTING_IS_ENABLED: False,
         }
     )
@@ -69,34 +77,21 @@ def test_base_url_trailing_slash_is_stripped():
     assert form.cleaned_data[SETTING_BASE_URL] == PUBLIC_URL
 
 
-def test_enabling_without_token_is_rejected():
+def test_enabling_without_connection_is_rejected():
     form = _form(
         {
             SETTING_BASE_URL: PUBLIC_URL,
-            SETTING_AUTH_TOKEN: "",
             SETTING_IS_ENABLED: True,
         }
     )
     assert not form.is_valid()
-    assert SETTING_AUTH_TOKEN in form.errors
+    assert SETTING_IS_ENABLED in form.errors
 
 
-def test_enabling_with_token_is_accepted():
+def test_enabling_with_existing_token_is_accepted():
     form = _form(
         {
             SETTING_BASE_URL: PUBLIC_URL,
-            SETTING_AUTH_TOKEN: "tok",
-            SETTING_IS_ENABLED: True,
-        }
-    )
-    assert form.is_valid(), form.errors
-
-
-def test_enabling_with_existing_token_and_redacted_input_is_accepted():
-    form = _form(
-        {
-            SETTING_BASE_URL: PUBLIC_URL,
-            SETTING_AUTH_TOKEN: "*****",
             SETTING_IS_ENABLED: True,
         },
         settings={SETTING_AUTH_TOKEN: "stored-token"},
@@ -104,26 +99,44 @@ def test_enabling_with_existing_token_and_redacted_input_is_accepted():
     assert form.is_valid(), form.errors
 
 
-def test_redacted_token_is_resolved_to_stored_value():
+def test_connect_requires_email_and_password():
     form = _form(
         {
             SETTING_BASE_URL: PUBLIC_URL,
-            SETTING_AUTH_TOKEN: "*****",
-            SETTING_IS_ENABLED: False,
-        },
-        settings={SETTING_AUTH_TOKEN: "stored-token"},
+            "susi_connect_email": "",
+            "susi_connect_password": "",
+            CONNECT_POST_KEY: "1",
+        }
     )
-    assert form.is_valid(), form.errors
-    assert form.cleaned_data[SETTING_AUTH_TOKEN] == "stored-token"
+    assert not form.is_valid()
+    assert "susi_connect_email" in form.errors
+    assert "susi_connect_password" in form.errors
 
 
-def test_new_token_is_stripped():
+def test_connect_with_credentials_is_valid(monkeypatch):
+    from django.contrib import messages
+
+    from interpretation.susi import SusiLoginResult
+
+    monkeypatch.setattr(messages, "success", lambda *a, **k: None)
+    monkeypatch.setattr(messages, "error", lambda *a, **k: None)
+
+    def fake_login(self, email, password):
+        return SusiLoginResult(token="jwt", email=email, name="Bot")
+
+    monkeypatch.setattr(
+        "interpretation.forms.SusiClient.login",
+        fake_login,
+    )
     form = _form(
         {
             SETTING_BASE_URL: PUBLIC_URL,
-            SETTING_AUTH_TOKEN: " tok ",
-            SETTING_IS_ENABLED: False,
+            "susi_connect_email": "bot@example.com",
+            "susi_connect_password": "secret",
+            CONNECT_POST_KEY: "1",
         }
     )
     assert form.is_valid(), form.errors
-    assert form.cleaned_data[SETTING_AUTH_TOKEN] == "tok"
+    form.run_connect_action(request=type("R", (), {})())
+    assert form.obj.settings.get(SETTING_AUTH_TOKEN) == "jwt"
+    assert form.obj.settings.get(SETTING_SUSI_EMAIL) == "bot@example.com"

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -167,7 +167,8 @@ def test_failed_connect_does_not_enable_interpretation(monkeypatch):
     assert form.is_valid(), form.errors
     form.save_pending_connect()
     form.run_connect_action(request=type("R", (), {})())
-    assert form.obj.settings.get(SETTING_IS_ENABLED, default=False, as_type=bool) is False
+    enabled = form.obj.settings.get(SETTING_IS_ENABLED, default=False, as_type=bool)
+    assert enabled is False
     assert not form.obj.settings.get(SETTING_AUTH_TOKEN)
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -140,3 +140,20 @@ def test_connect_with_credentials_is_valid(monkeypatch):
     form.run_connect_action(request=type("R", (), {})())
     assert form.obj.settings.get(SETTING_AUTH_TOKEN) == "jwt"
     assert form.obj.settings.get(SETTING_SUSI_EMAIL) == "bot@example.com"
+
+
+def test_save_does_not_persist_connect_credentials():
+    form = _form(
+        {
+            SETTING_BASE_URL: PUBLIC_URL,
+            "susi_connect_email": "bot@example.com",
+            "susi_connect_password": "secret",
+            SETTING_IS_ENABLED: False,
+        },
+    )
+    assert form.is_valid(), form.errors
+    form.save()
+    stored = form.obj.settings._data
+    assert "susi_connect_password" not in stored
+    assert "susi_connect_email" not in stored
+    assert stored.get(SETTING_BASE_URL) == PUBLIC_URL

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -137,9 +137,65 @@ def test_connect_with_credentials_is_valid(monkeypatch):
         }
     )
     assert form.is_valid(), form.errors
+    form.save_pending_connect()
     form.run_connect_action(request=type("R", (), {})())
     assert form.obj.settings.get(SETTING_AUTH_TOKEN) == "jwt"
     assert form.obj.settings.get(SETTING_SUSI_EMAIL) == "bot@example.com"
+
+
+def test_failed_connect_does_not_enable_interpretation(monkeypatch):
+    from django.contrib import messages
+
+    from interpretation.susi import SusiError
+
+    monkeypatch.setattr(messages, "success", lambda *a, **k: None)
+    monkeypatch.setattr(messages, "error", lambda *a, **k: None)
+
+    def fail_login(self, email, password):
+        raise SusiError("Invalid credentials")
+
+    monkeypatch.setattr("interpretation.forms.SusiClient.login", fail_login)
+    form = _form(
+        {
+            SETTING_BASE_URL: PUBLIC_URL,
+            "susi_connect_email": "bot@example.com",
+            "susi_connect_password": "wrong",
+            SETTING_IS_ENABLED: True,
+            CONNECT_POST_KEY: "1",
+        }
+    )
+    assert form.is_valid(), form.errors
+    form.save_pending_connect()
+    form.run_connect_action(request=type("R", (), {})())
+    assert form.obj.settings.get(SETTING_IS_ENABLED, default=False, as_type=bool) is False
+    assert not form.obj.settings.get(SETTING_AUTH_TOKEN)
+
+
+def test_successful_connect_with_enable_sets_enabled_flag(monkeypatch):
+    from django.contrib import messages
+
+    from interpretation.susi import SusiLoginResult
+
+    monkeypatch.setattr(messages, "success", lambda *a, **k: None)
+    monkeypatch.setattr(messages, "error", lambda *a, **k: None)
+
+    def fake_login(self, email, password):
+        return SusiLoginResult(token="jwt", email=email, name="Bot")
+
+    monkeypatch.setattr("interpretation.forms.SusiClient.login", fake_login)
+    form = _form(
+        {
+            SETTING_BASE_URL: PUBLIC_URL,
+            "susi_connect_email": "bot@example.com",
+            "susi_connect_password": "secret",
+            SETTING_IS_ENABLED: True,
+            CONNECT_POST_KEY: "1",
+        }
+    )
+    assert form.is_valid(), form.errors
+    form.save_pending_connect()
+    form.run_connect_action(request=type("R", (), {})())
+    assert form.obj.settings.get(SETTING_IS_ENABLED, as_type=bool) is True
 
 
 def test_save_does_not_persist_connect_credentials():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -8,6 +8,7 @@ from interpretation.settings import (
     get_base_url,
     get_susi_client,
     is_interpretation_enabled,
+    is_susi_configured,
 )
 
 
@@ -52,3 +53,24 @@ def test_get_susi_client_uses_event_settings():
     client = get_susi_client(event)
     assert client.base_url == "https://example.com/"
     assert client.auth_token == "tok"
+
+
+def test_is_susi_configured_requires_url_and_token():
+    assert is_susi_configured(_FakeEvent()) is False
+    assert (
+        is_susi_configured(
+            _FakeEvent({SETTING_BASE_URL: "https://example.com"})
+        )
+        is False
+    )
+    assert (
+        is_susi_configured(
+            _FakeEvent(
+                {
+                    SETTING_BASE_URL: "https://example.com",
+                    SETTING_AUTH_TOKEN: "tok",
+                }
+            )
+        )
+        is True
+    )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -57,12 +57,7 @@ def test_get_susi_client_uses_event_settings():
 
 def test_is_susi_configured_requires_url_and_token():
     assert is_susi_configured(_FakeEvent()) is False
-    assert (
-        is_susi_configured(
-            _FakeEvent({SETTING_BASE_URL: "https://example.com"})
-        )
-        is False
-    )
+    assert is_susi_configured(_FakeEvent({SETTING_BASE_URL: "https://example.com"})) is False
     assert (
         is_susi_configured(
             _FakeEvent(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -57,7 +57,8 @@ def test_get_susi_client_uses_event_settings():
 
 def test_is_susi_configured_requires_url_and_token():
     assert is_susi_configured(_FakeEvent()) is False
-    assert is_susi_configured(_FakeEvent({SETTING_BASE_URL: "https://example.com"})) is False
+    event_url_only = _FakeEvent({SETTING_BASE_URL: "https://example.com"})
+    assert is_susi_configured(event_url_only) is False
     assert (
         is_susi_configured(
             _FakeEvent(

--- a/tests/test_susi_client.py
+++ b/tests/test_susi_client.py
@@ -98,13 +98,16 @@ def test_login_returns_token_from_cookie(monkeypatch):
         assert url.endswith("/auth/api/login")
         assert kwargs["json"] == {"email": "a@b.c", "password": "secret"}
         return FakeResponse(
-            200, {"status": "success"}, cookies={"access_token_cookie": "jwt-xyz"}
+            200,
+            {"status": "success", "email": "a@b.c", "name": "Jane"},
+            cookies={"access_token_cookie": "jwt-xyz"},
         )
 
     monkeypatch.setattr(requests, "post", fake_post)
     client = SusiClient("https://example.com")
-    token = client.login("a@b.c", "secret")
-    assert token == "jwt-xyz"
+    result = client.login("a@b.c", "secret")
+    assert result.token == "jwt-xyz"
+    assert result.email == "a@b.c"
     assert client.auth_token == "jwt-xyz"
 
 


### PR DESCRIPTION
resolves #47 M1

## Summary

Adds email/password login on the commons interpretation dashboard so organizers could connect an event to SUSI without pasting a JWT manually. PR 4 of 5 in the milestone-1 stack.

## What changed

- Extended `SusiClient` with `login(email, password)` → JWT from SUSI auth API
- Replaced manual token entry with `InterpretationSettingsForm` (email, password, server URL, enable toggle)
- **Connect** — logs in, stores JWT + email/name in event settings
- **Disconnect** — clears stored credentials
- **Test connection** — verifies with stored token (or after connect)
- Dashboard templates: login form when disconnected; connected panel when authenticated
- Blocked enabling interpretation until event is connected to SUSI
- Added tests for form actions, settings helpers, and `SusiClient.login`

## Why

PR #45  moved credentials into event settings but still expected a raw token. This PR adds the real organizer flow: sign in with a SUSI account on the dashboard.

## Test plan

- [ ] `pytest` and `ruff check .` pass
- [ ] Commons → Interpretation: disconnected state shows email/password form
- [ ] Connect with valid SUSI credentials → success message, connected state shown
- [ ] Test connection works when connected
- [ ] Disconnect clears connection; login form returns
- [ ] Enable interpretation without connecting → validation error
- [ ] Invalid credentials → clear error, no token saved

## Stack

| PR | Branch | Status |
|----|--------|--------|
| 1 | `m1-susi-client` | #40 |
| 2 | `m1-models-dashboard-scaffold` | #41 |
| 3 | `m1-event-settings` | #44 |
| 4 | `m1-email-password-connect` | this PR |
| 5 | `m1-dashboard-redesign` | — |

Merge order: 1 → 2 → 3 → 4 → 5. 