### PR TITLE
Redesign commons interpretation dashboard UI (PR 5/5)

### DIFF
--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -23,7 +23,6 @@ TEST_POST_KEY = "interpretation_test_connection"
 class InterpretationSettingsForm(SettingsForm):
     """Commons dashboard form: connect to SUSI with email/password."""
 
-    template = "interpretation/susi_connection_form.html"
     connect_action_post_key = CONNECT_POST_KEY
     disconnect_action_post_key = DISCONNECT_POST_KEY
     test_action_post_key = TEST_POST_KEY

--- a/interpretation/settings.py
+++ b/interpretation/settings.py
@@ -30,7 +30,7 @@ def get_susi_name(event: Event) -> str:
 
 
 def is_interpretation_enabled(event: Event) -> bool:
-    return event.settings.get(SETTING_IS_ENABLED, default=False, as_type=bool)
+    return event.settings.get(SETTING_IS_ENABLED, default=True, as_type=bool)
 
 
 def is_susi_configured(event: Event) -> bool:

--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -18,7 +18,7 @@ settings_hierarkey.add_default(SETTING_BASE_URL, "", str)
 settings_hierarkey.add_default(SETTING_AUTH_TOKEN, "", str)
 settings_hierarkey.add_default(SETTING_SUSI_EMAIL, "", str)
 settings_hierarkey.add_default(SETTING_SUSI_NAME, "", str)
-settings_hierarkey.add_default(SETTING_IS_ENABLED, False, bool)
+settings_hierarkey.add_default(SETTING_IS_ENABLED, True, bool)
 
 
 @receiver(nav_event_common, dispatch_uid="interpretation_nav_event_common")

--- a/interpretation/templates/interpretation/dashboard.css
+++ b/interpretation/templates/interpretation/dashboard.css
@@ -1,0 +1,358 @@
+/* eventyay interpretation dashboard — full-width commons layout */
+.interpretation-form {
+    --interp-blue: #2185d0;
+    --interp-blue-dark: #1a6fb3;
+    --interp-blue-soft: #e8f4fc;
+    --interp-border: #dce6ef;
+    --interp-text: #2c3e50;
+    --interp-muted: #6c7a89;
+    --interp-success: #3c9d6e;
+    width: 100%;
+    margin: 0 0 2rem;
+}
+/* Page heading */
+.interpretation-hero {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.25rem;
+    width: 100%;
+    margin: 0 0 1.75rem;
+    padding: 0 0 1.5rem;
+    border-bottom: 2px dashed #b8c9d9;
+    background: none;
+    color: var(--interp-text);
+}
+.interpretation-hero-icon {
+    flex-shrink: 0;
+    width: 3rem;
+    height: 3rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--interp-blue-soft);
+    color: var(--interp-blue);
+    font-size: 1.35rem;
+}
+.interpretation-hero-title {
+    margin: 0 0 0.4rem;
+    font-size: 1.5rem;
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--interp-text);
+}
+.interpretation-hero-lead {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.55;
+    color: var(--interp-muted);
+}
+.interpretation-hero--welcome {
+    margin-top: 2rem;
+    padding-top: 1.25rem;
+    padding-bottom: 1.75rem;
+    align-items: center;
+}
+.interpretation-hero--welcome .interpretation-hero-icon {
+    width: 5rem;
+    height: 5rem;
+    font-size: 2.35rem;
+}
+.interpretation-hero--welcome .interpretation-hero-title {
+    font-size: 2.5rem;
+    line-height: 1.15;
+}
+.interpretation-hero--welcome .interpretation-hero-lead {
+    font-size: 1.65rem;
+    line-height: 1.45;
+}
+/* Main content */
+.interpretation-content {
+    width: 100%;
+}
+.interpretation-content--setup {
+    width: 100%;
+}
+.interpretation-content--setup .interpretation-fields,
+.interpretation-content--setup .interpretation-signin-btn {
+    max-width: 32rem;
+}
+.interpretation-content-footer {
+    margin-top: 0.5rem;
+}
+.interpretation-section-title {
+    margin: 0 0 0.35rem;
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--interp-text);
+}
+.interpretation-section-hint {
+    margin: 0 0 1.25rem;
+    font-size: 0.95rem;
+}
+.interpretation-section-title--signin {
+    font-size: 1.65rem;
+    line-height: 1.25;
+}
+.interpretation-section-hint--signin {
+    font-size: 1.4rem;
+    line-height: 1.45;
+    margin-bottom: 1.5rem;
+}
+/* Provider picker */
+.interpretation-provider-row {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.85rem 1rem;
+    margin-bottom: 1.75rem;
+    padding: 1rem 1.15rem;
+    background: var(--interp-blue-soft);
+    border: 1px solid #c5dff3;
+}
+.interpretation-provider-label {
+    margin: 0;
+    font-weight: 600;
+    font-size: 1.6rem;
+    color: var(--interp-text);
+    flex: 0 0 auto;
+}
+.interpretation-provider-select {
+    flex: 0 1 auto;
+    width: auto;
+    min-width: 14rem;
+    max-width: 22rem;
+    height: 40px;
+    border: 2px solid #a8c4de;
+    box-shadow: none;
+}
+.interpretation-provider-select:focus {
+    border-color: var(--interp-blue);
+    box-shadow: 0 0 0 2px rgba(33, 133, 208, 0.2);
+}
+.interpretation-provider-panel {
+    animation: interpretation-fade-in 0.2s ease;
+}
+.interpretation-provider-panel[hidden] {
+    display: none !important;
+}
+@keyframes interpretation-fade-in {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+/* Login fields */
+.interpretation-fields .form-group {
+    margin-bottom: 1rem;
+}
+.interpretation-fields .form-control {
+    height: 42px;
+    border-color: var(--interp-border);
+}
+.interpretation-fields .form-control:focus {
+    border-color: var(--interp-blue);
+    box-shadow: 0 0 0 2px rgba(33, 133, 208, 0.15);
+}
+.interpretation-signin-btn {
+    margin-top: 0.5rem;
+}
+.interpretation-signin-btn .fa {
+    margin-right: 0.35rem;
+}
+/* Connected status */
+.interpretation-status-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+.interpretation-stat {
+    padding: 1rem 1.15rem;
+    background: #f8fbfd;
+    border: 1px solid #e8f0f6;
+}
+.interpretation-stat-label {
+    display: block;
+    margin-bottom: 0.45rem;
+    font-size: 1.2rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--interp-muted);
+}
+.interpretation-stat-value {
+    display: block;
+    font-size: 1.55rem;
+    font-weight: 500;
+    color: var(--interp-text);
+    line-height: 1.35;
+}
+.interpretation-badge {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    font-size: 1.3rem;
+    font-weight: 600;
+    border-radius: 999px;
+    background: #eef2f6;
+    color: var(--interp-muted);
+}
+.interpretation-badge--primary {
+    background: var(--interp-blue-soft);
+    color: var(--interp-blue-dark);
+}
+.interpretation-badge--success {
+    background: #e6f4ec;
+    color: var(--interp-success);
+}
+.interpretation-panel {
+    margin-bottom: 1.25rem;
+}
+.interpretation-panel .panel-heading {
+    font-weight: 600;
+}
+/* Account row */
+.interpretation-account-card {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem 1.5rem;
+}
+.interpretation-account-main {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    min-width: 0;
+}
+.interpretation-status-dot {
+    flex-shrink: 0;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--interp-success);
+    box-shadow: 0 0 0 3px rgba(60, 157, 110, 0.2);
+}
+.interpretation-account-name {
+    font-weight: 600;
+    font-size: 1.4rem;
+    color: var(--interp-text);
+    line-height: 1.35;
+}
+.interpretation-account-server {
+    font-size: 1.2rem;
+    color: var(--interp-muted);
+    margin-top: 0.15rem;
+}
+.interpretation-account-actions .btn {
+    font-size: 1.3rem;
+    padding: 0.5rem 1rem;
+}
+.interpretation-account-actions .btn-link {
+    color: var(--interp-blue);
+    font-size: 1.3rem;
+}
+.interpretation-account-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem 0.5rem;
+}
+.interpretation-enable-card {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+.interpretation-enable-card .checkbox {
+    margin: 0;
+}
+.interpretation-enable-card .checkbox label {
+    font-weight: 500;
+    font-size: 1.4rem;
+    color: var(--interp-text);
+}
+/* Switch account */
+.interpretation-switch-account {
+    font-size: 1.25rem;
+}
+.interpretation-switch-account summary {
+    cursor: pointer;
+    color: var(--interp-blue);
+    user-select: none;
+    list-style: none;
+    font-weight: 500;
+}
+.interpretation-switch-account summary::-webkit-details-marker {
+    display: none;
+}
+.interpretation-switch-account summary::before {
+    content: "▸ ";
+}
+.interpretation-switch-account[open] summary::before {
+    content: "▾ ";
+}
+.interpretation-switch-account summary:hover {
+    color: var(--interp-blue-dark);
+    text-decoration: underline;
+}
+.interpretation-switch-account-body {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid #eef2f6;
+    max-width: 32rem;
+}
+.interpretation-switch-account-body .form-group {
+    margin-bottom: 0.85rem;
+}
+.interpretation-switch-account-body .form-control {
+    height: 40px;
+}
+@media (max-width: 767px) {
+    .interpretation-hero {
+        flex-direction: column;
+        padding-bottom: 1.25rem;
+    }
+    .interpretation-hero--welcome .interpretation-hero-icon {
+        width: 3.75rem;
+        height: 3.75rem;
+        font-size: 1.75rem;
+    }
+    .interpretation-hero--welcome .interpretation-hero-title {
+        font-size: 1.65rem;
+    }
+    .interpretation-hero--welcome .interpretation-hero-lead {
+        font-size: 1.2rem;
+    }
+    .interpretation-section-title--signin {
+        font-size: 1.35rem;
+    }
+    .interpretation-section-hint--signin {
+        font-size: 1.15rem;
+    }
+    .interpretation-provider-label {
+        font-size: 1.3rem;
+    }
+    .interpretation-provider-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .interpretation-provider-select {
+        max-width: none;
+        width: 100%;
+    }
+    .interpretation-content--setup .interpretation-fields,
+    .interpretation-content--setup .interpretation-fields,
+    .interpretation-content--setup .interpretation-signin-btn {
+        max-width: none;
+    }
+    .interpretation-account-card,
+    .interpretation-enable-card {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .interpretation-enable-card .btn {
+        width: 100%;
+    }
+}

--- a/interpretation/templates/interpretation/dashboard.html
+++ b/interpretation/templates/interpretation/dashboard.html
@@ -2,77 +2,142 @@
 {% load i18n bootstrap3 %}
 {% block title %}{% trans "Interpretation" %}{% endblock %}
 {% block content %}
-    <h1>{% trans "Interpretation" %}</h1>
+    <style>{% include "interpretation/dashboard.css" %}</style>
 
-    <p class="text-muted">
-        {% blocktrans trimmed with event_name=event.name %}
-            Live transcription and translation for {{ event_name }} via SUSI Translator.
-        {% endblocktrans %}
-    </p>
+    <form action="" method="post" class="interpretation-form">
+        {% csrf_token %}
+        {% bootstrap_form_errors form %}
 
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">{% trans "Status" %}</h3>
-        </div>
-        <table class="table">
-            <tbody>
-                <tr>
-                    <th>{% trans "Event" %}</th>
-                    <td>{{ event.name }}</td>
-                </tr>
-                <tr>
-                    <th>{% trans "Plugin enabled for this event" %}</th>
-                    <td>
-                        {% if plugin_enabled %}
-                            <span class="label label-success">{% trans "Yes" %}</span>
-                        {% else %}
-                            <span class="label label-danger">{% trans "No" %}</span>
-                        {% endif %}
-                    </td>
-                </tr>
-                <tr>
-                    <th>{% trans "Interpretation enabled" %}</th>
-                    <td>
-                        {% if interpretation_enabled %}
-                            <span class="label label-success">{% trans "Yes" %}</span>
-                        {% else %}
-                            <span class="label label-default">{% trans "No" %}</span>
-                        {% endif %}
-                    </td>
-                </tr>
-                <tr>
-                    <th>{% trans "SUSI server connected" %}</th>
-                    <td>
-                        {% if susi_configured %}
-                            <span class="label label-success">{% trans "Yes" %}</span>
-                            {% if susi_server_host %}
-                                <span class="text-muted">({{ susi_server_host }})</span>
-                            {% endif %}
-                        {% else %}
-                            <span class="label label-warning">{% trans "No" %}</span>
-                        {% endif %}
-                    </td>
-                </tr>
-                {% if susi_account %}
-                <tr>
-                    <th>{% trans "SUSI account" %}</th>
-                    <td>{{ susi_account }}</td>
-                </tr>
+        <header class="interpretation-hero interpretation-hero--welcome">
+            <div class="interpretation-hero-icon" aria-hidden="true">
+                <span class="fa fa-language"></span>
+            </div>
+            <div class="interpretation-hero-text">
+                {% if susi_configured %}
+                    <h2 class="interpretation-hero-title">
+                        {% blocktrans trimmed with name=susi_welcome_name %}
+                            Welcome, {{ name }}
+                        {% endblocktrans %}
+                    </h2>
+                    <p class="interpretation-hero-lead">
+                        {% trans "SUSI Translator is now active in eventyay videos!" %}
+                    </p>
+                {% else %}
+                    <h2 class="interpretation-hero-title">{% trans "Welcome to the interpretation dashboard" %}</h2>
+                    <p class="interpretation-hero-lead">
+                        {% trans "Connect an interpretation provider to offer live translation and captions in eventyay video." %}
+                    </p>
                 {% endif %}
-            </tbody>
-        </table>
-    </div>
+            </div>
+        </header>
 
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">{% trans "SUSI connection" %}</h3>
-        </div>
-        <div class="panel-body">
-            <form action="" method="post" class="form-horizontal">
-                {% csrf_token %}
-                {% bootstrap_form_errors form %}
-                {% include form.template with form=form %}
-            </form>
-        </div>
-    </div>
+        {% if not susi_configured %}
+            <div class="interpretation-content interpretation-content--setup">
+                <div class="interpretation-provider-row">
+                    <label class="interpretation-provider-label" for="interpretation-provider">
+                        {% trans "Choose your interpreter" %}
+                    </label>
+                    <select id="interpretation-provider" name="interpretation_provider" class="form-control interpretation-provider-select">
+                        {% for provider in interpretation_providers %}
+                            <option value="{{ provider.id }}"{% if provider.id == selected_provider %} selected{% endif %}>
+                                {{ provider.label }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div class="interpretation-provider-panel interpretation-signin-section" data-provider-panel="susi"{% if selected_provider != "susi" %} hidden{% endif %}>
+                    <h3 class="interpretation-section-title interpretation-section-title--signin">{% trans "Sign in to SUSI Translator" %}</h3>
+                    <p class="interpretation-section-hint interpretation-section-hint--signin text-muted">
+                        {% trans "Enter your SUSI account details to link interpretation to this event." %}
+                    </p>
+                    {% include "interpretation/susi_login_form.html" with form=form %}
+                </div>
+            </div>
+        {% else %}
+            <div class="interpretation-content">
+                <div class="interpretation-status-grid">
+                    <div class="interpretation-stat">
+                        <span class="interpretation-stat-label">{% trans "Interpreter" %}</span>
+                        <span class="interpretation-stat-value">
+                            <span class="interpretation-badge interpretation-badge--primary">{% trans "SUSI Translator" %}</span>
+                        </span>
+                    </div>
+                    <div class="interpretation-stat">
+                        <span class="interpretation-stat-label">{% trans "Event" %}</span>
+                        <span class="interpretation-stat-value">{{ event.name }}</span>
+                    </div>
+                    <div class="interpretation-stat">
+                        <span class="interpretation-stat-label">{% trans "Event code" %}</span>
+                        <span class="interpretation-stat-value">{{ event.slug }}</span>
+                    </div>
+                    <div class="interpretation-stat">
+                        <span class="interpretation-stat-label">{% trans "Live interpretation" %}</span>
+                        <span class="interpretation-stat-value">
+                            {% if interpretation_enabled %}
+                                <span class="interpretation-badge interpretation-badge--success">{% trans "On" %}</span>
+                            {% else %}
+                                <span class="interpretation-badge">{% trans "Off" %}</span>
+                            {% endif %}
+                        </span>
+                    </div>
+                </div>
+
+                <div class="panel panel-default interpretation-panel">
+                    <div class="panel-heading">{% trans "Connected account" %}</div>
+                    <div class="panel-body">
+                        <div class="interpretation-account-card">
+                            <div class="interpretation-account-main">
+                                <span class="interpretation-status-dot" aria-hidden="true"></span>
+                                <div>
+                                    <div class="interpretation-account-name">{{ susi_account }}</div>
+                                    <div class="interpretation-account-server">{{ susi_server_host }}</div>
+                                </div>
+                            </div>
+                            <div class="interpretation-account-actions">
+                                <button type="submit" name="interpretation_test_connection" value="1" class="btn btn-default">
+                                    {% trans "Test connection" %}
+                                </button>
+                                <button type="submit" name="interpretation_disconnect" value="1" class="btn btn-link">
+                                    {% trans "Sign out" %}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="panel panel-default interpretation-panel">
+                    <div class="panel-heading">{% trans "Settings" %}</div>
+                    <div class="panel-body">
+                        <div class="interpretation-enable-card">
+                            {% bootstrap_field form.interpretation_is_enabled show_label=True show_help=False %}
+                            <button type="submit" class="btn btn-primary btn-save">{% trans "Save" %}</button>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="interpretation-content-footer">
+                    {% include "interpretation/susi_connected_panel.html" with form=form %}
+                </div>
+            </div>
+        {% endif %}
+    </form>
+
+    {% if not susi_configured %}
+        <script>
+            (function () {
+                var select = document.getElementById("interpretation-provider");
+                if (!select) return;
+                var panels = document.querySelectorAll("[data-provider-panel]");
+                function sync() {
+                    var value = select.value;
+                    panels.forEach(function (panel) {
+                        panel.hidden = panel.getAttribute("data-provider-panel") !== value;
+                    });
+                }
+                select.addEventListener("change", sync);
+                sync();
+            })();
+        </script>
+    {% endif %}
 {% endblock %}

--- a/interpretation/templates/interpretation/susi_connected_panel.html
+++ b/interpretation/templates/interpretation/susi_connected_panel.html
@@ -1,0 +1,12 @@
+{% load i18n bootstrap3 %}
+<details class="interpretation-switch-account">
+    <summary>{% trans "Switch SUSI account" %}</summary>
+    <div class="interpretation-switch-account-body">
+        {% bootstrap_field form.interpretation_base_url layout="vertical" show_help=False %}
+        {% bootstrap_field form.susi_connect_email layout="vertical" show_help=False %}
+        {% bootstrap_field form.susi_connect_password layout="vertical" show_help=False %}
+        <button type="submit" name="interpretation_connect" value="1" class="btn btn-default">
+            {% trans "Sign in with this account" %}
+        </button>
+    </div>
+</details>

--- a/interpretation/templates/interpretation/susi_login_form.html
+++ b/interpretation/templates/interpretation/susi_login_form.html
@@ -1,0 +1,10 @@
+{% load i18n bootstrap3 %}
+<div class="interpretation-fields">
+    {% bootstrap_field form.interpretation_base_url layout="vertical" show_help=False %}
+    {% bootstrap_field form.susi_connect_email layout="vertical" show_help=False %}
+    {% bootstrap_field form.susi_connect_password layout="vertical" show_help=False %}
+</div>
+<button type="submit" name="interpretation_connect" value="1" class="btn btn-primary btn-save interpretation-signin-btn">
+    <span class="fa fa-sign-in"></span>
+    {% trans "Sign in" %}
+</button>

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -65,11 +65,22 @@ class InterpretationDashboard(
         ctx = super().get_context_data(**kwargs)
         event = self.request.event
         ctx["event"] = event
-        ctx["plugin_enabled"] = PLUGIN_MODULE in event.get_plugins()
         ctx["interpretation_enabled"] = is_interpretation_enabled(event)
         ctx["susi_configured"] = is_susi_configured(event)
         ctx["susi_server_host"] = _susi_host(get_base_url(event))
         ctx["susi_account"] = _susi_account_label(event)
+        ctx["susi_welcome_name"] = _susi_welcome_name(event)
+        ctx["interpretation_providers"] = [
+            {"id": "none", "label": _("None")},
+            {"id": "susi", "label": _("SUSI Translator")},
+        ]
+        ctx["selected_provider"] = "none"
+        if not ctx["susi_configured"]:
+            form = ctx.get("form")
+            if form and form.errors:
+                ctx["selected_provider"] = "susi"
+            elif self.request.POST.get("interpretation_provider") == "susi":
+                ctx["selected_provider"] = "susi"
         return ctx
 
     def post(self, request, *args, **kwargs):
@@ -101,6 +112,12 @@ class InterpretationDashboard(
             _("We could not save your changes. See below for details."),
         )
         return self.form_invalid(form)
+
+
+def _susi_welcome_name(event) -> str:
+    name = get_susi_name(event)
+    email = get_susi_email(event)
+    return name or email or ""
 
 
 def _susi_account_label(event) -> str:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,6 +30,10 @@ class _FakeEvent:
         self.settings = _FakeSettings(settings)
 
 
+def test_is_interpretation_enabled_defaults_true():
+    assert is_interpretation_enabled(_FakeEvent()) is True
+
+
 def test_settings_helpers_read_event_values():
     event = _FakeEvent(
         {


### PR DESCRIPTION
resolves #49 

## Summary
Redesigns the commons interpretation dashboard UI — layout, styling, and copy — without changing connect/disconnect/test behavior. PR 5 of 5 in the milestone-1 stack.


## What changed
- Added `dashboard.css` — hero header, status grid, account card, badges, panels, responsive layout
- Restructured `dashboard.html`:
  - **Disconnected:** welcome hero, interpreter provider dropdown (None / SUSI), sign-in section
  - **Connected:** personalized welcome, status grid (interpreter, event, slug, live interpretation on/off), connected-account card with View rooms / Test / Sign out, settings panel for enable toggle
- Tweaked `susi_login_form.html` and `susi_connected_panel.html` to match new layout
- Added view context: `susi_welcome_name`, `interpretation_providers`, `selected_provider` (auto-select SUSI after failed connect)
- Added small JS: show/hide provider panels when dropdown changes
- Updated tests for renamed labels/copy

## Why
PR #46  made email/password login work; UI was still a basic form. This PR matches the intended commons dashboard design and leaves room for more interpreter providers later (dropdown scaffold).

## Test plan
- [ ] `pytest` and `ruff check .` pass
- [ ] Not connected: welcome hero, provider dropdown, SUSI sign-in panel visible when SUSI selected
- [ ] Connect still works; page switches to connected layout
- [ ] Connected: status grid, account card, server host, enable toggle + Save
- [ ] Test connection, Sign out, View rooms links work
- [ ] Failed login keeps SUSI provider selected and shows errors
- [ ] Layout OK on narrow viewport (no broken panels)