### PR TITLE
feat: room level interpretation session, auth event level

### DIFF
--- a/interpretation/backends/__init__.py
+++ b/interpretation/backends/__init__.py
@@ -1,0 +1,13 @@
+from .registry import (
+    INTERPRETER_NONE,
+    INTERPRETER_SUSI,
+    get_backend,
+    list_available_interpreters,
+)
+
+__all__ = [
+    "INTERPRETER_NONE",
+    "INTERPRETER_SUSI",
+    "get_backend",
+    "list_available_interpreters",
+]

--- a/interpretation/backends/base.py
+++ b/interpretation/backends/base.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from eventyay.base.models import Event
+
+    from ..models import RoomInterpretation
+
+
+class InterpreterBackend(Protocol):
+    id: str
+    label: str
+
+    def is_configured(self, event: Event) -> bool: ...
+
+    def start(
+        self,
+        event: Event,
+        interpretation: RoomInterpretation,
+        *,
+        stream_url: str,
+    ) -> str: ...
+
+    def stop(self, event: Event, interpretation: RoomInterpretation) -> None: ...

--- a/interpretation/backends/none.py
+++ b/interpretation/backends/none.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from django.utils.translation import gettext_lazy as _
+
+from ..models import RoomInterpretation
+
+
+class NoopBackend:
+    id = RoomInterpretation.INTERPRETER_NONE
+    label = _("None")
+
+    def is_configured(self, event) -> bool:
+        return True
+
+    def start(self, event, interpretation, *, stream_url: str) -> str:
+        raise ValueError("Cannot start a session without an interpreter.")
+
+    def stop(self, event, interpretation) -> None:
+        return None

--- a/interpretation/backends/registry.py
+++ b/interpretation/backends/registry.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from .none import NoopBackend
+from .susi import SusiBackend
+
+INTERPRETER_NONE = NoopBackend.id
+INTERPRETER_SUSI = SusiBackend.id
+
+_BACKENDS = {
+    INTERPRETER_NONE: NoopBackend(),
+    INTERPRETER_SUSI: SusiBackend(),
+}
+
+
+def get_backend(interpreter_id: str):
+    return _BACKENDS.get(interpreter_id, _BACKENDS[INTERPRETER_NONE])
+
+
+def list_available_interpreters(event) -> list[dict]:
+    return [
+        {
+            "id": backend.id,
+            "label": str(backend.label),
+            "configured": backend.is_configured(event),
+        }
+        for backend in _BACKENDS.values()
+    ]

--- a/interpretation/backends/susi.py
+++ b/interpretation/backends/susi.py
@@ -22,6 +22,8 @@ class SusiBackend:
             stream_url,
             transcription_provider=interpretation.transcription_provider,
             translation_provider=interpretation.translation_provider,
+            source_language=interpretation.source_language,
+            target_languages=list(interpretation.target_languages or []),
         )
 
     def stop(self, event, interpretation) -> None:

--- a/interpretation/backends/susi.py
+++ b/interpretation/backends/susi.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from django.utils.translation import gettext_lazy as _
+
+from ..models import RoomInterpretation
+from ..services import start_stream_session
+from ..settings import get_susi_client, is_susi_connected
+from ..susi import SusiError
+
+
+class SusiBackend:
+    id = RoomInterpretation.INTERPRETER_SUSI
+    label = _("SUSI Translator")
+
+    def is_configured(self, event) -> bool:
+        return is_susi_connected(event)
+
+    def start(self, event, interpretation, *, stream_url: str) -> str:
+        client = get_susi_client(event)
+        return start_stream_session(
+            client,
+            stream_url,
+            transcription_provider=interpretation.transcription_provider,
+            translation_provider=interpretation.translation_provider,
+        )
+
+    def stop(self, event, interpretation) -> None:
+        session_id = interpretation.backend_session_id
+        if not session_id:
+            return
+        client = get_susi_client(event)
+        try:
+            client.stop_session(session_id)
+        except SusiError:
+            raise

--- a/interpretation/backends/susi.py
+++ b/interpretation/backends/susi.py
@@ -32,6 +32,8 @@ class SusiBackend:
             return
         client = get_susi_client(event)
         try:
-            client.stop_session(session_id)
+            result = client.stop_session(session_id)
         except SusiError:
             raise
+        if not result.ok:
+            raise SusiError(f"Failed to stop SUSI session: {result.data}")

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -136,7 +136,15 @@ class InterpretationSettingsForm(SettingsForm):
         # ponytail: login fields are POST-only; never write them to event.settings.
         was_enabled = is_interpretation_enabled(self.obj) if self.obj else True
         result = self._save_excluding_fields(self._TRANSIENT_FIELDS)
-        if self.obj and was_enabled and not is_interpretation_enabled(self.obj):
+        enable_key = (
+            f"{self.prefix}-{SETTING_IS_ENABLED}" if self.prefix else SETTING_IS_ENABLED
+        )
+        if (
+            self.obj
+            and was_enabled
+            and not is_interpretation_enabled(self.obj)
+            and enable_key in self.data
+        ):
             from .room_control import stop_all_event_sessions
 
             stop_all_event_sessions(self.obj)

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -3,6 +3,7 @@ from django.contrib import messages
 from django.utils.translation import gettext_lazy as _
 from eventyay.base.forms import SettingsForm
 
+from .models import RoomInterpretation
 from .settings import (
     SETTING_BASE_URL,
     SETTING_IS_ENABLED,
@@ -205,3 +206,54 @@ class InterpretationSettingsForm(SettingsForm):
                 request,
                 _("Connection issue: %(message)s") % {"message": result.message},
             )
+
+
+class RoomInterpretationForm(forms.ModelForm):
+    """Per-room interpretation configuration.
+
+    ``target_languages`` is stored as a JSON list but edited as a
+    comma-separated string for convenience.
+    """
+
+    target_languages = forms.CharField(
+        required=False,
+        label=_("Caption languages"),
+        help_text=_(
+            "Comma-separated language codes attendees can read captions in, e.g. de, fr."
+        ),
+        widget=forms.TextInput(attrs={"placeholder": "de, fr, es"}),
+    )
+
+    class Meta:
+        model = RoomInterpretation
+        fields = [
+            "stream_url",
+            "target_languages",
+            "transcription_provider",
+            "translation_provider",
+        ]
+        widgets = {
+            "stream_url": forms.URLInput(
+                attrs={
+                    "placeholder": (
+                        "https://www.youtube.com/watch?v=… or https://…/stream.m3u8"
+                    )
+                }
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and isinstance(self.instance.target_languages, list):
+            self.initial["target_languages"] = ", ".join(self.instance.target_languages)
+
+    def clean_target_languages(self):
+        raw = self.cleaned_data.get("target_languages") or ""
+        codes = [c.strip() for c in raw.split(",") if c.strip()]
+        seen = set()
+        result = []
+        for code in codes:
+            if code not in seen:
+                seen.add(code)
+                result.append(code)
+        return result

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -227,7 +227,8 @@ class RoomInterpretationForm(forms.ModelForm):
         required=False,
         label=_("Caption languages"),
         help_text=_(
-            "Comma-separated language codes attendees can read captions in, e.g. de, fr."
+            "Comma-separated language codes attendees can read captions in, "
+            "e.g. de, fr."
         ),
         widget=forms.TextInput(attrs={"placeholder": "de, fr, es"}),
     )

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -6,6 +6,7 @@ from eventyay.base.forms import SettingsForm
 from .models import RoomInterpretation
 from .settings import (
     SETTING_BASE_URL,
+    SETTING_IS_ENABLED,
     disconnect_susi,
     get_auth_token,
     get_base_url,
@@ -44,6 +45,10 @@ class InterpretationSettingsForm(SettingsForm):
         required=False,
         widget=forms.PasswordInput(render_value=False),
     )
+    interpretation_is_enabled = forms.BooleanField(
+        label=_("Enable live interpretation for this event"),
+        required=False,
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -51,6 +56,7 @@ class InterpretationSettingsForm(SettingsForm):
             "interpretation_base_url",
             "susi_connect_email",
             "susi_connect_password",
+            "interpretation_is_enabled",
         ):
             self.fields[name].widget.attrs.setdefault("class", "form-control")
         if self.obj and get_susi_email(self.obj):
@@ -100,6 +106,18 @@ class InterpretationSettingsForm(SettingsForm):
                     _("Password is required to connect."),
                 )
 
+        if cleaned.get(SETTING_IS_ENABLED):
+            if not base_url:
+                self.add_error(
+                    SETTING_BASE_URL,
+                    _("A SUSI server URL is required to enable interpretation."),
+                )
+            if not get_auth_token(self.obj) and not self._connecting():
+                self.add_error(
+                    SETTING_IS_ENABLED,
+                    _("Connect to SUSI before enabling interpretation."),
+                )
+
         return cleaned
 
     _TRANSIENT_FIELDS = frozenset({"susi_connect_password", "susi_connect_email"})
@@ -118,8 +136,9 @@ class InterpretationSettingsForm(SettingsForm):
         return self._save_excluding_fields(self._TRANSIENT_FIELDS)
 
     def save_pending_connect(self):
-        """Persist URL before login; credentials stay transient."""
-        return self._save_excluding_fields(self._TRANSIENT_FIELDS)
+        """Persist URL before login; defer is_enabled until connect succeeds."""
+        excluded = self._TRANSIENT_FIELDS | {SETTING_IS_ENABLED}
+        return self._save_excluding_fields(excluded)
 
     def run_connect_action(self, request):
         base_url = self.cleaned_data.get(SETTING_BASE_URL) or get_base_url(self.obj)
@@ -139,6 +158,9 @@ class InterpretationSettingsForm(SettingsForm):
             token=result.token,
             email=result.email,
             name=result.name,
+        )
+        self.obj.settings.set(
+            SETTING_IS_ENABLED, bool(self.cleaned_data.get(SETTING_IS_ENABLED))
         )
         label = result.name or result.email
         if result.name and result.email:

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -6,7 +6,6 @@ from eventyay.base.forms import SettingsForm
 from .models import RoomInterpretation
 from .settings import (
     SETTING_BASE_URL,
-    SETTING_IS_ENABLED,
     disconnect_susi,
     get_auth_token,
     get_base_url,
@@ -35,11 +34,6 @@ class InterpretationSettingsForm(SettingsForm):
         ),
         required=False,
         widget=forms.URLInput(attrs={"placeholder": "https://susi.example.com"}),
-    )
-    interpretation_is_enabled = forms.BooleanField(
-        label=_("Enable interpretation"),
-        help_text=_("Master switch for SUSI interpretation on this event."),
-        required=False,
     )
     susi_connect_email = forms.EmailField(
         label=_("SUSI account email"),
@@ -106,17 +100,6 @@ class InterpretationSettingsForm(SettingsForm):
                     _("Password is required to connect."),
                 )
 
-        if cleaned.get(SETTING_IS_ENABLED):
-            if not base_url:
-                self.add_error(
-                    SETTING_BASE_URL,
-                    _("A SUSI server URL is required to enable interpretation."),
-                )
-            if not get_auth_token(self.obj) and not self._connecting():
-                self.add_error(
-                    SETTING_IS_ENABLED,
-                    _("Connect to SUSI before enabling interpretation."),
-                )
         return cleaned
 
     _TRANSIENT_FIELDS = frozenset({"susi_connect_password", "susi_connect_email"})
@@ -135,9 +118,8 @@ class InterpretationSettingsForm(SettingsForm):
         return self._save_excluding_fields(self._TRANSIENT_FIELDS)
 
     def save_pending_connect(self):
-        """Persist URL before login; defer is_enabled until connect succeeds."""
-        excluded = self._TRANSIENT_FIELDS | {SETTING_IS_ENABLED}
-        return self._save_excluding_fields(excluded)
+        """Persist URL before login; credentials stay transient."""
+        return self._save_excluding_fields(self._TRANSIENT_FIELDS)
 
     def run_connect_action(self, request):
         base_url = self.cleaned_data.get(SETTING_BASE_URL) or get_base_url(self.obj)
@@ -157,9 +139,6 @@ class InterpretationSettingsForm(SettingsForm):
             token=result.token,
             email=result.email,
             name=result.name,
-        )
-        self.obj.settings.set(
-            SETTING_IS_ENABLED, bool(self.cleaned_data.get(SETTING_IS_ENABLED))
         )
         label = result.name or result.email
         if result.name and result.email:
@@ -227,6 +206,8 @@ class RoomInterpretationForm(forms.ModelForm):
     class Meta:
         model = RoomInterpretation
         fields = [
+            "interpreter",
+            "room_enabled",
             "stream_url",
             "target_languages",
             "transcription_provider",

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -12,6 +12,7 @@ from .settings import (
     get_base_url,
     get_susi_email,
     get_susi_name,
+    is_interpretation_enabled,
     save_susi_connection,
 )
 from .susi import SusiClient, SusiError
@@ -133,7 +134,13 @@ class InterpretationSettingsForm(SettingsForm):
 
     def save(self):
         # ponytail: login fields are POST-only; never write them to event.settings.
-        return self._save_excluding_fields(self._TRANSIENT_FIELDS)
+        was_enabled = is_interpretation_enabled(self.obj) if self.obj else True
+        result = self._save_excluding_fields(self._TRANSIENT_FIELDS)
+        if self.obj and was_enabled and not is_interpretation_enabled(self.obj):
+            from .room_control import stop_all_event_sessions
+
+            stop_all_event_sessions(self.obj)
+        return result
 
     def save_pending_connect(self):
         """Persist URL before login; defer is_enabled until connect succeeds."""

--- a/interpretation/migrations/0003_rename_hls_url_stream_url.py
+++ b/interpretation/migrations/0003_rename_hls_url_stream_url.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("interpretation", "0002_move_connection_to_event_settings"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="roominterpretation",
+            old_name="hls_url",
+            new_name="stream_url",
+        ),
+    ]

--- a/interpretation/migrations/0004_per_room_interpreter.py
+++ b/interpretation/migrations/0004_per_room_interpreter.py
@@ -1,0 +1,64 @@
+from django.db import migrations, models
+
+
+def backfill_interpreter_from_session(apps, schema_editor):
+    RoomInterpretation = apps.get_model("interpretation", "RoomInterpretation")
+    for row in RoomInterpretation.objects.exclude(backend_session_id=""):
+        row.interpreter = "susi"
+        row.save(update_fields=["interpreter"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("interpretation", "0003_rename_hls_url_stream_url"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="roominterpretation",
+            old_name="susi_session_id",
+            new_name="backend_session_id",
+        ),
+        migrations.AddField(
+            model_name="roominterpretation",
+            name="interpreter",
+            field=models.CharField(
+                choices=[("none", "None"), ("susi", "SUSI Translator")],
+                default="none",
+                max_length=32,
+                verbose_name="Interpreter",
+            ),
+        ),
+        migrations.AddField(
+            model_name="roominterpretation",
+            name="room_enabled",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When enabled, this room can run interpretation using the "
+                    "selected interpreter."
+                ),
+                verbose_name="Interpretation enabled for room",
+            ),
+        ),
+        migrations.AddField(
+            model_name="roominterpretation",
+            name="backend_config",
+            field=models.JSONField(blank=True, default=dict, verbose_name="Backend config"),
+        ),
+        migrations.RunPython(
+            backfill_interpreter_from_session,
+            migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="roominterpretation",
+            name="backend_session_id",
+            field=models.CharField(
+                blank=True,
+                help_text="Session/tenant ID returned by the active interpreter backend.",
+                max_length=64,
+                verbose_name="Backend session ID",
+            ),
+        ),
+    ]

--- a/interpretation/migrations/0004_per_room_interpreter.py
+++ b/interpretation/migrations/0004_per_room_interpreter.py
@@ -1,11 +1,80 @@
 from django.db import migrations, models
 
 
+def _column_names(schema_editor, table):
+    with schema_editor.connection.cursor() as cursor:
+        return {
+            col.name
+            for col in schema_editor.connection.introspection.get_table_description(
+                cursor, table
+            )
+        }
+
+
+def apply_database_changes(apps, schema_editor):
+    """Apply schema changes, skipping columns already present from branch-hopping."""
+    model = apps.get_model("interpretation", "RoomInterpretation")
+    table = model._meta.db_table
+    columns = _column_names(schema_editor, table)
+
+    if "susi_session_id" in columns and "backend_session_id" not in columns:
+        schema_editor.execute(
+            schema_editor.sql_rename_column
+            % {
+                "table": schema_editor.quote_name(table),
+                "old_column": schema_editor.quote_name("susi_session_id"),
+                "new_column": schema_editor.quote_name("backend_session_id"),
+            }
+        )
+        columns.remove("susi_session_id")
+        columns.add("backend_session_id")
+
+    if "interpreter" not in columns:
+        field = models.CharField(
+            choices=[("none", "None"), ("susi", "SUSI Translator")],
+            default="none",
+            max_length=32,
+            verbose_name="Interpreter",
+        )
+        field.set_attributes_from_name("interpreter")
+        schema_editor.add_field(model, field)
+
+    if "room_enabled" not in columns:
+        field = models.BooleanField(
+            default=False,
+            help_text=(
+                "When enabled, this room can run interpretation using the "
+                "selected interpreter."
+            ),
+            verbose_name="Interpretation enabled for room",
+        )
+        field.set_attributes_from_name("room_enabled")
+        schema_editor.add_field(model, field)
+
+    if "backend_config" not in columns:
+        field = models.JSONField(
+            blank=True, default=dict, verbose_name="Backend config"
+        )
+        field.set_attributes_from_name("backend_config")
+        schema_editor.add_field(model, field)
+
+
 def backfill_interpreter_from_session(apps, schema_editor):
     RoomInterpretation = apps.get_model("interpretation", "RoomInterpretation")
-    for row in RoomInterpretation.objects.exclude(backend_session_id=""):
-        row.interpreter = "susi"
-        row.save(update_fields=["interpreter"])
+    table = RoomInterpretation._meta.db_table
+    columns = _column_names(schema_editor, table)
+    if "interpreter" not in columns:
+        return
+
+    session_column = (
+        "backend_session_id"
+        if "backend_session_id" in columns
+        else "susi_session_id"
+    )
+    for row in RoomInterpretation.objects.exclude(**{f"{session_column}": ""}):
+        if row.interpreter == "none":
+            row.interpreter = "susi"
+            row.save(update_fields=["interpreter"])
 
 
 class Migration(migrations.Migration):
@@ -15,50 +84,64 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RenameField(
-            model_name="roominterpretation",
-            old_name="susi_session_id",
-            new_name="backend_session_id",
-        ),
-        migrations.AddField(
-            model_name="roominterpretation",
-            name="interpreter",
-            field=models.CharField(
-                choices=[("none", "None"), ("susi", "SUSI Translator")],
-                default="none",
-                max_length=32,
-                verbose_name="Interpreter",
-            ),
-        ),
-        migrations.AddField(
-            model_name="roominterpretation",
-            name="room_enabled",
-            field=models.BooleanField(
-                default=False,
-                help_text=(
-                    "When enabled, this room can run interpretation using the "
-                    "selected interpreter."
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunPython(
+                    apply_database_changes,
+                    migrations.RunPython.noop,
                 ),
-                verbose_name="Interpretation enabled for room",
-            ),
-        ),
-        migrations.AddField(
-            model_name="roominterpretation",
-            name="backend_config",
-            field=models.JSONField(blank=True, default=dict, verbose_name="Backend config"),
+            ],
+            state_operations=[
+                migrations.RenameField(
+                    model_name="roominterpretation",
+                    old_name="susi_session_id",
+                    new_name="backend_session_id",
+                ),
+                migrations.AddField(
+                    model_name="roominterpretation",
+                    name="interpreter",
+                    field=models.CharField(
+                        choices=[("none", "None"), ("susi", "SUSI Translator")],
+                        default="none",
+                        max_length=32,
+                        verbose_name="Interpreter",
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="roominterpretation",
+                    name="room_enabled",
+                    field=models.BooleanField(
+                        default=False,
+                        help_text=(
+                            "When enabled, this room can run interpretation using the "
+                            "selected interpreter."
+                        ),
+                        verbose_name="Interpretation enabled for room",
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="roominterpretation",
+                    name="backend_config",
+                    field=models.JSONField(
+                        blank=True, default=dict, verbose_name="Backend config"
+                    ),
+                ),
+                migrations.AlterField(
+                    model_name="roominterpretation",
+                    name="backend_session_id",
+                    field=models.CharField(
+                        blank=True,
+                        help_text=(
+                            "Session/tenant ID returned by the active interpreter backend."
+                        ),
+                        max_length=64,
+                        verbose_name="Backend session ID",
+                    ),
+                ),
+            ],
         ),
         migrations.RunPython(
             backfill_interpreter_from_session,
             migrations.RunPython.noop,
-        ),
-        migrations.AlterField(
-            model_name="roominterpretation",
-            name="backend_session_id",
-            field=models.CharField(
-                blank=True,
-                help_text="Session/tenant ID returned by the active interpreter backend.",
-                max_length=64,
-                verbose_name="Backend session ID",
-            ),
         ),
     ]

--- a/interpretation/migrations/0005_normalize_legacy_session_status.py
+++ b/interpretation/migrations/0005_normalize_legacy_session_status.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def normalize_legacy_status(apps, schema_editor):
+    RoomInterpretation = apps.get_model("interpretation", "RoomInterpretation")
+    RoomInterpretation.objects.filter(status__in=["stopped", "error"]).update(
+        status="idle",
+        backend_session_id="",
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("interpretation", "0004_per_room_interpreter"),
+    ]
+
+    operations = [
+        migrations.RunPython(normalize_legacy_status, migrations.RunPython.noop),
+    ]

--- a/interpretation/models.py
+++ b/interpretation/models.py
@@ -6,21 +6,20 @@ from eventyay.base.models import LoggedModel
 class RoomInterpretation(LoggedModel):
     """Interpretation configuration and session state for a single room.
 
-    Each room maps to one SUSI transcription session, fed by the room's HLS
-    stream and translated into the configured target languages. Per-event SUSI
+    Each room maps to one SUSI transcription session, fed by the room's
+    stream URL and translated into the configured target languages. Per-event SUSI
     connection settings live in the event settings backend (see
     :mod:`interpretation.settings`).
     """
 
     STATUS_IDLE = "idle"
     STATUS_RUNNING = "running"
+    # Legacy DB values; normalized to idle on read/write.
     STATUS_STOPPED = "stopped"
     STATUS_ERROR = "error"
     STATUS_CHOICES = (
         (STATUS_IDLE, _("Idle")),
         (STATUS_RUNNING, _("Running")),
-        (STATUS_STOPPED, _("Stopped")),
-        (STATUS_ERROR, _("Error")),
     )
 
     room = models.OneToOneField(
@@ -28,12 +27,12 @@ class RoomInterpretation(LoggedModel):
         on_delete=models.CASCADE,
         related_name="interpretation",
     )
-    hls_url = models.URLField(
-        verbose_name=_("HLS stream URL"),
+    stream_url = models.URLField(
+        verbose_name=_("Stream URL"),
         blank=True,
         help_text=_(
-            "HLS (.m3u8) URL of the room's audio/video stream that SUSI will "
-            "ingest. Defaults from the room's stream configuration when empty."
+            "Stream URL that SUSI will ingest (YouTube, HLS, Vimeo, …). "
+            "Defaults from the room configuration when empty."
         ),
     )
     source_language = models.CharField(

--- a/interpretation/models.py
+++ b/interpretation/models.py
@@ -4,13 +4,19 @@ from eventyay.base.models import LoggedModel
 
 
 class RoomInterpretation(LoggedModel):
-    """Interpretation configuration and session state for a single room.
+    """Per-room interpretation configuration and session state.
 
-    Each room maps to one SUSI transcription session, fed by the room's
-    stream URL and translated into the configured target languages. Per-event SUSI
-    connection settings live in the event settings backend (see
+    Each room selects its own interpreter backend and runs sessions
+    independently. Event-level settings store shared credentials (see
     :mod:`interpretation.settings`).
     """
+
+    INTERPRETER_NONE = "none"
+    INTERPRETER_SUSI = "susi"
+    INTERPRETER_CHOICES = (
+        (INTERPRETER_NONE, _("None")),
+        (INTERPRETER_SUSI, _("SUSI Translator")),
+    )
 
     STATUS_IDLE = "idle"
     STATUS_RUNNING = "running"
@@ -27,11 +33,25 @@ class RoomInterpretation(LoggedModel):
         on_delete=models.CASCADE,
         related_name="interpretation",
     )
+    interpreter = models.CharField(
+        verbose_name=_("Interpreter"),
+        max_length=32,
+        choices=INTERPRETER_CHOICES,
+        default=INTERPRETER_NONE,
+    )
+    room_enabled = models.BooleanField(
+        verbose_name=_("Interpretation enabled for room"),
+        default=False,
+        help_text=_(
+            "When enabled, this room can run interpretation using the "
+            "selected interpreter."
+        ),
+    )
     stream_url = models.URLField(
         verbose_name=_("Stream URL"),
         blank=True,
         help_text=_(
-            "Stream URL that SUSI will ingest (YouTube, HLS, Vimeo, …). "
+            "Stream URL that the interpreter will ingest (YouTube, HLS, Vimeo, …). "
             "Defaults from the room configuration when empty."
         ),
     )
@@ -57,11 +77,16 @@ class RoomInterpretation(LoggedModel):
         max_length=50,
         blank=True,
     )
-    susi_session_id = models.CharField(
-        verbose_name=_("SUSI session/tenant ID"),
+    backend_config = models.JSONField(
+        verbose_name=_("Backend config"),
+        default=dict,
+        blank=True,
+    )
+    backend_session_id = models.CharField(
+        verbose_name=_("Backend session ID"),
         max_length=64,
         blank=True,
-        help_text=_("Tenant ID returned by SUSI when the session starts."),
+        help_text=_("Session/tenant ID returned by the active interpreter backend."),
     )
     status = models.CharField(
         verbose_name=_("Status"),
@@ -75,4 +100,7 @@ class RoomInterpretation(LoggedModel):
         verbose_name_plural = _("Room interpretations")
 
     def __str__(self):
-        return f"RoomInterpretation(room={self.room_id}, status={self.status})"
+        return (
+            f"RoomInterpretation(room={self.room_id}, "
+            f"interpreter={self.interpreter}, status={self.status})"
+        )

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -196,6 +196,12 @@ def start_room_session(
             interpretation=interpretation,
         )
 
+    if (
+        interpretation.backend_session_id
+        and interpretation.status == RoomInterpretation.STATUS_RUNNING
+    ):
+        return SessionResult(ok=True, interpretation=interpretation)
+
     try:
         session_id = backend.start(event, interpretation, stream_url=stream_url)
     except (SusiError, ValueError) as exc:

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -8,9 +8,15 @@ from django.utils.translation import gettext_lazy as _
 
 from .backends import get_backend, list_available_interpreters
 from .models import RoomInterpretation
-from .settings import is_susi_connected
+from .settings import is_interpretation_enabled, is_susi_connected
 from .susi import SusiError
-from .utils import get_room_stream_url, normalize_target_languages, interpretation_dashboard_url
+from .utils import (
+    get_room_stream_url,
+    interpretation_dashboard_url,
+    normalize_target_languages,
+    validate_backend_config,
+    validate_target_language_codes,
+)
 
 PLUGIN_MODULE = "interpretation"
 
@@ -89,8 +95,8 @@ def serialize_room_interpretation(room, event, interpretation=None) -> dict:
 
 
 def _apply_backend_config(interpretation: RoomInterpretation, data: dict) -> None:
-    if "backend_config" in data and isinstance(data.get("backend_config"), dict):
-        interpretation.backend_config = dict(data["backend_config"])
+    if "backend_config" in data:
+        interpretation.backend_config = validate_backend_config(data["backend_config"])
     if "transcription_provider" in data:
         interpretation.transcription_provider = (
             data.get("transcription_provider") or ""
@@ -129,8 +135,8 @@ def update_room_interpretation(room, event, data: dict) -> RoomInterpretation:
         interpretation.room_enabled = bool(data.get("room_enabled"))
 
     if "target_languages" in data:
-        interpretation.target_languages = normalize_target_languages(
-            data.get("target_languages")
+        interpretation.target_languages = validate_target_language_codes(
+            normalize_target_languages(data.get("target_languages"))
         )
 
     _apply_backend_config(interpretation, data)
@@ -158,6 +164,13 @@ def start_room_session(
     room, event, *, stream_url_override: str = ""
 ) -> SessionResult:
     interpretation, _created = RoomInterpretation.objects.get_or_create(room=room)
+
+    if not is_interpretation_enabled(event):
+        return SessionResult(
+            ok=False,
+            error=str(_("Live interpretation is turned off for this event.")),
+            interpretation=interpretation,
+        )
 
     if not interpretation.room_enabled:
         return SessionResult(
@@ -226,7 +239,21 @@ def start_room_session(
     return SessionResult(ok=True, interpretation=interpretation)
 
 
-def stop_room_session(room, event) -> SessionResult:
+def _clear_local_session(interpretation: RoomInterpretation, *, session_id: str = "") -> None:
+    if hasattr(interpretation, "log_action") and session_id:
+        interpretation.log_action(
+            "interpretation.room.stopped",
+            data={
+                "interpreter": interpretation.interpreter,
+                "session_id": session_id,
+            },
+        )
+    interpretation.status = RoomInterpretation.STATUS_IDLE
+    interpretation.backend_session_id = ""
+    interpretation.save()
+
+
+def stop_room_session(room, event, *, force_clear: bool = False) -> SessionResult:
     interpretation = get_interpretation(room)
     if interpretation is None or not interpretation.backend_session_id:
         return SessionResult(
@@ -239,17 +266,19 @@ def stop_room_session(room, event) -> SessionResult:
     try:
         backend.stop(event, interpretation)
     except SusiError as exc:
-        return SessionResult(ok=False, error=str(exc), interpretation=interpretation)
+        if not force_clear:
+            return SessionResult(ok=False, error=str(exc), interpretation=interpretation)
 
-    if hasattr(interpretation, "log_action"):
-        interpretation.log_action(
-            "interpretation.room.stopped",
-            data={
-                "interpreter": interpretation.interpreter,
-                "session_id": session_id,
-            },
-        )
-    interpretation.status = RoomInterpretation.STATUS_IDLE
-    interpretation.backend_session_id = ""
-    interpretation.save()
+    _clear_local_session(interpretation, session_id=session_id)
     return SessionResult(ok=True, interpretation=interpretation)
+
+
+def stop_all_event_sessions(event) -> None:
+    """Stop every room session for an event (e.g. before SUSI disconnect)."""
+    interpretations = (
+        RoomInterpretation.objects.filter(room__event=event)
+        .exclude(backend_session_id="")
+        .select_related("room")
+    )
+    for interpretation in interpretations:
+        stop_room_session(interpretation.room, event, force_clear=True)

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -73,9 +73,7 @@ def serialize_room_interpretation(room, event, interpretation=None) -> dict:
         "interpreter": interpreter,
         "interpreter_label": str(backend.label),
         "room_enabled": room_enabled,
-        "interpreter_ready": is_room_interpretation_ready(
-            room, event, interpretation
-        ),
+        "interpreter_ready": is_room_interpretation_ready(room, event, interpretation),
         "available_interpreters": list_available_interpreters(event),
         "target_languages": list(interpretation.target_languages or [])
         if interpretation
@@ -97,9 +95,7 @@ def serialize_room_interpretation(room, event, interpretation=None) -> dict:
         "detected_stream_url": detected_stream_url,
         "plugin_enabled": plugin_enabled(event),
         "susi_connected": is_susi_connected(event),
-        "dashboard_url": interpretation_dashboard_url(
-            event.organizer.slug, event.slug
-        ),
+        "dashboard_url": interpretation_dashboard_url(event.organizer.slug, event.slug),
     }
 
 
@@ -173,9 +169,7 @@ class SessionResult:
     interpretation: RoomInterpretation | None = None
 
 
-def start_room_session(
-    room, event, *, stream_url_override: str = ""
-) -> SessionResult:
+def start_room_session(room, event, *, stream_url_override: str = "") -> SessionResult:
     interpretation, _created = RoomInterpretation.objects.get_or_create(room=room)
 
     if not is_interpretation_enabled(event):
@@ -232,9 +226,7 @@ def start_room_session(
     try:
         session_id = backend.start(event, interpretation, stream_url=stream_url)
     except (SusiError, ValueError) as exc:
-        interpretation.status = normalize_session_status(
-            RoomInterpretation.STATUS_IDLE
-        )
+        interpretation.status = normalize_session_status(RoomInterpretation.STATUS_IDLE)
         interpretation.backend_session_id = ""
         interpretation.stream_url = stream_url
         interpretation.save()
@@ -242,9 +234,7 @@ def start_room_session(
 
     interpretation.backend_session_id = session_id
     interpretation.stream_url = stream_url
-    interpretation.status = normalize_session_status(
-        RoomInterpretation.STATUS_RUNNING
-    )
+    interpretation.status = normalize_session_status(RoomInterpretation.STATUS_RUNNING)
     interpretation.save()
     if hasattr(interpretation, "log_action"):
         interpretation.log_action(

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -122,7 +122,9 @@ def update_room_interpretation(room, event, data: dict) -> RoomInterpretation:
     old_interpreter = interpretation.interpreter
 
     if "interpreter" in data:
-        interpreter = (data.get("interpreter") or RoomInterpretation.INTERPRETER_NONE).strip()
+        interpreter = (
+            data.get("interpreter") or RoomInterpretation.INTERPRETER_NONE
+        ).strip()
         if interpreter not in {
             RoomInterpretation.INTERPRETER_NONE,
             RoomInterpretation.INTERPRETER_SUSI,
@@ -256,7 +258,9 @@ def start_room_session(
     return SessionResult(ok=True, interpretation=interpretation)
 
 
-def _clear_local_session(interpretation: RoomInterpretation, *, session_id: str = "") -> None:
+def _clear_local_session(
+    interpretation: RoomInterpretation, *, session_id: str = ""
+) -> None:
     if hasattr(interpretation, "log_action") and session_id:
         interpretation.log_action(
             "interpretation.room.stopped",

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -211,21 +211,26 @@ def start_room_session(
 
     if (
         interpretation.backend_session_id
-        and interpretation.status == RoomInterpretation.STATUS_RUNNING
+        and normalize_session_status(interpretation.status)
+        == RoomInterpretation.STATUS_RUNNING
     ):
         return SessionResult(ok=True, interpretation=interpretation)
 
     try:
         session_id = backend.start(event, interpretation, stream_url=stream_url)
     except (SusiError, ValueError) as exc:
-        interpretation.status = RoomInterpretation.STATUS_IDLE
+        interpretation.status = normalize_session_status(
+            RoomInterpretation.STATUS_IDLE
+        )
         interpretation.stream_url = stream_url
         interpretation.save()
         return SessionResult(ok=False, error=str(exc), interpretation=interpretation)
 
     interpretation.backend_session_id = session_id
     interpretation.stream_url = stream_url
-    interpretation.status = RoomInterpretation.STATUS_RUNNING
+    interpretation.status = normalize_session_status(
+        RoomInterpretation.STATUS_RUNNING
+    )
     interpretation.save()
     if hasattr(interpretation, "log_action"):
         interpretation.log_action(
@@ -248,12 +253,12 @@ def _clear_local_session(interpretation: RoomInterpretation, *, session_id: str 
                 "session_id": session_id,
             },
         )
-    interpretation.status = RoomInterpretation.STATUS_IDLE
+    interpretation.status = normalize_session_status(RoomInterpretation.STATUS_IDLE)
     interpretation.backend_session_id = ""
     interpretation.save()
 
 
-def stop_room_session(room, event, *, force_clear: bool = False) -> SessionResult:
+def stop_room_session(room, event) -> SessionResult:
     interpretation = get_interpretation(room)
     if interpretation is None or not interpretation.backend_session_id:
         return SessionResult(
@@ -263,13 +268,19 @@ def stop_room_session(room, event, *, force_clear: bool = False) -> SessionResul
 
     backend = get_backend(interpretation.interpreter)
     session_id = interpretation.backend_session_id
+    remote_error = ""
     try:
         backend.stop(event, interpretation)
     except SusiError as exc:
-        if not force_clear:
-            return SessionResult(ok=False, error=str(exc), interpretation=interpretation)
+        remote_error = str(exc)
 
     _clear_local_session(interpretation, session_id=session_id)
+    if remote_error:
+        return SessionResult(
+            ok=False,
+            error=remote_error,
+            interpretation=interpretation,
+        )
     return SessionResult(ok=True, interpretation=interpretation)
 
 
@@ -281,4 +292,4 @@ def stop_all_event_sessions(event) -> None:
         .select_related("room")
     )
     for interpretation in interpretations:
-        stop_room_session(interpretation.room, event, force_clear=True)
+        stop_room_session(interpretation.room, event)

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -1,0 +1,165 @@
+"""Shared per-room interpretation helpers for commons views and video admin API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.utils.translation import gettext_lazy as _
+
+from .models import RoomInterpretation
+from .services import start_stream_session
+from .settings import get_susi_client, is_susi_configured, is_susi_connected, is_interpretation_enabled
+from .susi import SusiError
+from .utils import get_room_stream_url, normalize_target_languages, interpretation_dashboard_url
+
+PLUGIN_MODULE = "interpretation"
+
+
+def plugin_enabled(event) -> bool:
+    return PLUGIN_MODULE in event.get_plugins()
+
+
+def get_interpretation(room) -> RoomInterpretation | None:
+    return RoomInterpretation.objects.filter(room=room).first()
+
+
+def normalize_session_status(status: str) -> str:
+    """Map legacy stopped/error rows to idle for display and API."""
+    if status == RoomInterpretation.STATUS_RUNNING:
+        return RoomInterpretation.STATUS_RUNNING
+    return RoomInterpretation.STATUS_IDLE
+
+
+def serialize_room_interpretation(room, event, interpretation=None) -> dict:
+    if interpretation is None:
+        interpretation = get_interpretation(room)
+    detected_stream_url = get_room_stream_url(room)
+    stream_url = ""
+    if interpretation and interpretation.stream_url:
+        stream_url = interpretation.stream_url
+    return {
+        "target_languages": list(interpretation.target_languages or [])
+        if interpretation
+        else [],
+        "transcription_provider": interpretation.transcription_provider
+        if interpretation
+        else "",
+        "translation_provider": interpretation.translation_provider
+        if interpretation
+        else "",
+        "status": normalize_session_status(
+            interpretation.status if interpretation else RoomInterpretation.STATUS_IDLE
+        ),
+        "session_id": interpretation.susi_session_id if interpretation else "",
+        "stream_url": stream_url or detected_stream_url,
+        "detected_stream_url": detected_stream_url,
+        "plugin_enabled": plugin_enabled(event),
+        "susi_connected": is_susi_connected(event),
+        "interpretation_enabled": is_interpretation_enabled(event),
+        "interpretation_ready": is_susi_configured(event),
+        "dashboard_url": interpretation_dashboard_url(
+            event.organizer.slug, event.slug
+        ),
+    }
+
+
+def update_room_interpretation(room, event, data: dict) -> RoomInterpretation:
+    if not is_susi_connected(event):
+        raise ValueError(_("Connect to SUSI on the interpretation dashboard first."))
+
+    interpretation, _created = RoomInterpretation.objects.get_or_create(room=room)
+    if "target_languages" in data:
+        interpretation.target_languages = normalize_target_languages(
+            data.get("target_languages")
+        )
+    if "transcription_provider" in data:
+        interpretation.transcription_provider = (
+            data.get("transcription_provider") or ""
+        ).strip()
+    if "translation_provider" in data:
+        interpretation.translation_provider = (
+            data.get("translation_provider") or ""
+        ).strip()
+    interpretation.save()
+    return interpretation
+
+
+@dataclass
+class SessionResult:
+    ok: bool
+    error: str = ""
+    interpretation: RoomInterpretation | None = None
+
+
+def start_room_session(
+    room, event, *, stream_url_override: str = ""
+) -> SessionResult:
+    if not is_susi_configured(event):
+        return SessionResult(
+            ok=False,
+            error=str(
+                _(
+                    "Connect and enable SUSI on the interpretation dashboard before starting a room."
+                )
+            ),
+        )
+
+    interpretation, _created = RoomInterpretation.objects.get_or_create(room=room)
+    override = (stream_url_override or "").strip()
+    stream_url = override or interpretation.stream_url or get_room_stream_url(room)
+    if not stream_url:
+        return SessionResult(
+            ok=False,
+            error=str(_("No stream URL is configured for this room.")),
+            interpretation=interpretation,
+        )
+
+    client = get_susi_client(event)
+    try:
+        tenant_id = start_stream_session(
+            client,
+            stream_url,
+            transcription_provider=interpretation.transcription_provider,
+            translation_provider=interpretation.translation_provider,
+        )
+    except SusiError as exc:
+        interpretation.status = RoomInterpretation.STATUS_IDLE
+        interpretation.stream_url = stream_url
+        interpretation.save()
+        return SessionResult(ok=False, error=str(exc), interpretation=interpretation)
+
+    interpretation.susi_session_id = tenant_id
+    interpretation.stream_url = stream_url
+    interpretation.status = RoomInterpretation.STATUS_RUNNING
+    interpretation.save()
+    if hasattr(interpretation, "log_action"):
+        interpretation.log_action(
+            "interpretation.room.started",
+            data={"tenant_id": tenant_id, "stream_url": stream_url},
+        )
+    return SessionResult(ok=True, interpretation=interpretation)
+
+
+def stop_room_session(room, event) -> SessionResult:
+    interpretation = get_interpretation(room)
+    if interpretation is None or not interpretation.susi_session_id:
+        return SessionResult(
+            ok=False,
+            error=str(_("No running interpretation session for this room.")),
+        )
+
+    client = get_susi_client(event)
+    try:
+        client.stop_session(interpretation.susi_session_id)
+    except SusiError as exc:
+        return SessionResult(ok=False, error=str(exc), interpretation=interpretation)
+
+    if hasattr(interpretation, "log_action"):
+        interpretation.log_action(
+            "interpretation.room.stopped",
+            data={"tenant_id": interpretation.susi_session_id},
+        )
+    interpretation.status = RoomInterpretation.STATUS_IDLE
+    interpretation.susi_session_id = ""
+    interpretation.save()
+    return SessionResult(ok=True, interpretation=interpretation)

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -36,6 +36,15 @@ def normalize_session_status(status: str) -> str:
     return RoomInterpretation.STATUS_IDLE
 
 
+def _public_session_id(interpretation: RoomInterpretation | None) -> str:
+    if interpretation is None:
+        return ""
+    status = normalize_session_status(interpretation.status)
+    if status != RoomInterpretation.STATUS_RUNNING:
+        return ""
+    return interpretation.backend_session_id or ""
+
+
 def is_room_interpretation_ready(
     room, event, interpretation: RoomInterpretation | None = None
 ) -> bool:
@@ -83,7 +92,7 @@ def serialize_room_interpretation(room, event, interpretation=None) -> dict:
         "status": normalize_session_status(
             interpretation.status if interpretation else RoomInterpretation.STATUS_IDLE
         ),
-        "session_id": interpretation.backend_session_id if interpretation else "",
+        "session_id": _public_session_id(interpretation),
         "stream_url": stream_url or detected_stream_url,
         "detected_stream_url": detected_stream_url,
         "plugin_enabled": plugin_enabled(event),
@@ -147,8 +156,10 @@ def update_room_interpretation(room, event, data: dict) -> RoomInterpretation:
         or interpretation.interpreter == RoomInterpretation.INTERPRETER_NONE
         or interpretation.interpreter != old_interpreter
     ):
-        stop_room_session(room, event)
+        result = stop_room_session(room, event)
         interpretation.refresh_from_db()
+        if not result.ok:
+            raise ValueError(result.error)
 
     return interpretation
 
@@ -222,6 +233,7 @@ def start_room_session(
         interpretation.status = normalize_session_status(
             RoomInterpretation.STATUS_IDLE
         )
+        interpretation.backend_session_id = ""
         interpretation.stream_url = stream_url
         interpretation.save()
         return SessionResult(ok=False, error=str(exc), interpretation=interpretation)

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass
 
 from django.utils.translation import gettext_lazy as _
 
+from .backends import get_backend, list_available_interpreters
 from .models import RoomInterpretation
-from .services import start_stream_session
-from .settings import get_susi_client, is_susi_configured, is_susi_connected, is_interpretation_enabled
+from .settings import is_susi_connected
 from .susi import SusiError
 from .utils import get_room_stream_url, normalize_target_languages, interpretation_dashboard_url
 
@@ -30,14 +30,38 @@ def normalize_session_status(status: str) -> str:
     return RoomInterpretation.STATUS_IDLE
 
 
+def is_room_interpretation_ready(
+    room, event, interpretation: RoomInterpretation | None = None
+) -> bool:
+    if interpretation is None:
+        interpretation = get_interpretation(room)
+    if interpretation is None or not interpretation.room_enabled:
+        return False
+    if interpretation.interpreter == RoomInterpretation.INTERPRETER_NONE:
+        return False
+    return get_backend(interpretation.interpreter).is_configured(event)
+
+
 def serialize_room_interpretation(room, event, interpretation=None) -> dict:
     if interpretation is None:
         interpretation = get_interpretation(room)
     detected_stream_url = get_room_stream_url(room)
     stream_url = ""
-    if interpretation and interpretation.stream_url:
-        stream_url = interpretation.stream_url
+    interpreter = RoomInterpretation.INTERPRETER_NONE
+    room_enabled = False
+    if interpretation:
+        stream_url = interpretation.stream_url or ""
+        interpreter = interpretation.interpreter
+        room_enabled = interpretation.room_enabled
+    backend = get_backend(interpreter)
     return {
+        "interpreter": interpreter,
+        "interpreter_label": str(backend.label),
+        "room_enabled": room_enabled,
+        "interpreter_ready": is_room_interpretation_ready(
+            room, event, interpretation
+        ),
+        "available_interpreters": list_available_interpreters(event),
         "target_languages": list(interpretation.target_languages or [])
         if interpretation
         else [],
@@ -47,31 +71,26 @@ def serialize_room_interpretation(room, event, interpretation=None) -> dict:
         "translation_provider": interpretation.translation_provider
         if interpretation
         else "",
+        "backend_config": dict(interpretation.backend_config or {})
+        if interpretation
+        else {},
         "status": normalize_session_status(
             interpretation.status if interpretation else RoomInterpretation.STATUS_IDLE
         ),
-        "session_id": interpretation.susi_session_id if interpretation else "",
+        "session_id": interpretation.backend_session_id if interpretation else "",
         "stream_url": stream_url or detected_stream_url,
         "detected_stream_url": detected_stream_url,
         "plugin_enabled": plugin_enabled(event),
         "susi_connected": is_susi_connected(event),
-        "interpretation_enabled": is_interpretation_enabled(event),
-        "interpretation_ready": is_susi_configured(event),
         "dashboard_url": interpretation_dashboard_url(
             event.organizer.slug, event.slug
         ),
     }
 
 
-def update_room_interpretation(room, event, data: dict) -> RoomInterpretation:
-    if not is_susi_connected(event):
-        raise ValueError(_("Connect to SUSI on the interpretation dashboard first."))
-
-    interpretation, _created = RoomInterpretation.objects.get_or_create(room=room)
-    if "target_languages" in data:
-        interpretation.target_languages = normalize_target_languages(
-            data.get("target_languages")
-        )
+def _apply_backend_config(interpretation: RoomInterpretation, data: dict) -> None:
+    if "backend_config" in data and isinstance(data.get("backend_config"), dict):
+        interpretation.backend_config = dict(data["backend_config"])
     if "transcription_provider" in data:
         interpretation.transcription_provider = (
             data.get("transcription_provider") or ""
@@ -80,7 +99,51 @@ def update_room_interpretation(room, event, data: dict) -> RoomInterpretation:
         interpretation.translation_provider = (
             data.get("translation_provider") or ""
         ).strip()
+
+
+def update_room_interpretation(room, event, data: dict) -> RoomInterpretation:
+    interpretation, _created = RoomInterpretation.objects.get_or_create(room=room)
+    was_running = bool(interpretation.backend_session_id)
+    old_interpreter = interpretation.interpreter
+
+    if "interpreter" in data:
+        interpreter = (data.get("interpreter") or RoomInterpretation.INTERPRETER_NONE).strip()
+        if interpreter not in {
+            RoomInterpretation.INTERPRETER_NONE,
+            RoomInterpretation.INTERPRETER_SUSI,
+        }:
+            raise ValueError(_("Unknown interpreter."))
+        if interpreter != RoomInterpretation.INTERPRETER_NONE:
+            backend = get_backend(interpreter)
+            if not backend.is_configured(event):
+                raise ValueError(
+                    _(
+                        "Connect %(name)s on the interpretation dashboard before "
+                        "selecting it for this room."
+                    )
+                    % {"name": backend.label}
+                )
+        interpretation.interpreter = interpreter
+
+    if "room_enabled" in data:
+        interpretation.room_enabled = bool(data.get("room_enabled"))
+
+    if "target_languages" in data:
+        interpretation.target_languages = normalize_target_languages(
+            data.get("target_languages")
+        )
+
+    _apply_backend_config(interpretation, data)
     interpretation.save()
+
+    if was_running and (
+        not interpretation.room_enabled
+        or interpretation.interpreter == RoomInterpretation.INTERPRETER_NONE
+        or interpretation.interpreter != old_interpreter
+    ):
+        stop_room_session(room, event)
+        interpretation.refresh_from_db()
+
     return interpretation
 
 
@@ -94,17 +157,36 @@ class SessionResult:
 def start_room_session(
     room, event, *, stream_url_override: str = ""
 ) -> SessionResult:
-    if not is_susi_configured(event):
+    interpretation, _created = RoomInterpretation.objects.get_or_create(room=room)
+
+    if not interpretation.room_enabled:
+        return SessionResult(
+            ok=False,
+            error=str(_("Interpretation is disabled for this room.")),
+            interpretation=interpretation,
+        )
+
+    if interpretation.interpreter == RoomInterpretation.INTERPRETER_NONE:
+        return SessionResult(
+            ok=False,
+            error=str(_("Select an interpreter for this room before starting.")),
+            interpretation=interpretation,
+        )
+
+    backend = get_backend(interpretation.interpreter)
+    if not backend.is_configured(event):
         return SessionResult(
             ok=False,
             error=str(
                 _(
-                    "Connect and enable SUSI on the interpretation dashboard before starting a room."
+                    "Connect %(name)s on the interpretation dashboard before "
+                    "starting this room."
                 )
+                % {"name": backend.label}
             ),
+            interpretation=interpretation,
         )
 
-    interpretation, _created = RoomInterpretation.objects.get_or_create(room=room)
     override = (stream_url_override or "").strip()
     stream_url = override or interpretation.stream_url or get_room_stream_url(room)
     if not stream_url:
@@ -114,52 +196,54 @@ def start_room_session(
             interpretation=interpretation,
         )
 
-    client = get_susi_client(event)
     try:
-        tenant_id = start_stream_session(
-            client,
-            stream_url,
-            transcription_provider=interpretation.transcription_provider,
-            translation_provider=interpretation.translation_provider,
-        )
-    except SusiError as exc:
+        session_id = backend.start(event, interpretation, stream_url=stream_url)
+    except (SusiError, ValueError) as exc:
         interpretation.status = RoomInterpretation.STATUS_IDLE
         interpretation.stream_url = stream_url
         interpretation.save()
         return SessionResult(ok=False, error=str(exc), interpretation=interpretation)
 
-    interpretation.susi_session_id = tenant_id
+    interpretation.backend_session_id = session_id
     interpretation.stream_url = stream_url
     interpretation.status = RoomInterpretation.STATUS_RUNNING
     interpretation.save()
     if hasattr(interpretation, "log_action"):
         interpretation.log_action(
             "interpretation.room.started",
-            data={"tenant_id": tenant_id, "stream_url": stream_url},
+            data={
+                "interpreter": interpretation.interpreter,
+                "session_id": session_id,
+                "stream_url": stream_url,
+            },
         )
     return SessionResult(ok=True, interpretation=interpretation)
 
 
 def stop_room_session(room, event) -> SessionResult:
     interpretation = get_interpretation(room)
-    if interpretation is None or not interpretation.susi_session_id:
+    if interpretation is None or not interpretation.backend_session_id:
         return SessionResult(
             ok=False,
             error=str(_("No running interpretation session for this room.")),
         )
 
-    client = get_susi_client(event)
+    backend = get_backend(interpretation.interpreter)
+    session_id = interpretation.backend_session_id
     try:
-        client.stop_session(interpretation.susi_session_id)
+        backend.stop(event, interpretation)
     except SusiError as exc:
         return SessionResult(ok=False, error=str(exc), interpretation=interpretation)
 
     if hasattr(interpretation, "log_action"):
         interpretation.log_action(
             "interpretation.room.stopped",
-            data={"tenant_id": interpretation.susi_session_id},
+            data={
+                "interpreter": interpretation.interpreter,
+                "session_id": session_id,
+            },
         )
     interpretation.status = RoomInterpretation.STATUS_IDLE
-    interpretation.susi_session_id = ""
+    interpretation.backend_session_id = ""
     interpretation.save()
     return SessionResult(ok=True, interpretation=interpretation)

--- a/interpretation/services.py
+++ b/interpretation/services.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .susi import SusiError
 from .utils import SUSI_STREAM_TYPE
 
 
@@ -50,15 +51,22 @@ def start_stream_session(
         raise ValueError("stream_url is required to start a session")
 
     tenant_id = client.create_session(source=SUSI_STREAM_TYPE)
-    client.configure(
-        tenant_id,
-        stream_url=stream_url,
-        stream_type=SUSI_STREAM_TYPE,
-        transcription=_provider_config(transcription_provider),
-        translation=_translation_config(
-            translation_provider,
-            source_language=source_language,
-            target_languages=target_languages,
-        ),
-    )
+    try:
+        client.configure(
+            tenant_id,
+            stream_url=stream_url,
+            stream_type=SUSI_STREAM_TYPE,
+            transcription=_provider_config(transcription_provider),
+            translation=_translation_config(
+                translation_provider,
+                source_language=source_language,
+                target_languages=target_languages,
+            ),
+        )
+    except Exception:
+        try:
+            client.stop_session(tenant_id)
+        except SusiError:
+            pass
+        raise
     return tenant_id

--- a/interpretation/services.py
+++ b/interpretation/services.py
@@ -9,12 +9,34 @@ def _provider_config(provider_name: str):
     return {"provider_name": provider_name} if provider_name else None
 
 
+def _translation_config(
+    provider_name: str,
+    *,
+    source_language: str = "",
+    target_languages: list[str] | None = None,
+):
+    if not provider_name:
+        return None
+    cfg = {"provider_name": provider_name}
+    source = (source_language or "").strip()
+    if source:
+        cfg["source_lang"] = source
+    targets = [(code or "").strip() for code in (target_languages or [])]
+    targets = [code for code in targets if code]
+    if targets:
+        # ponytail: SUSI default target_lang; viewers override per SSE connection.
+        cfg["target_lang"] = targets[0]
+    return cfg
+
+
 def start_stream_session(
     client,
     stream_url: str,
     *,
     transcription_provider: str = "",
     translation_provider: str = "",
+    source_language: str = "",
+    target_languages: list[str] | None = None,
 ) -> str:
     """Create a SUSI session and configure it to ingest ``stream_url``.
 
@@ -33,6 +55,10 @@ def start_stream_session(
         stream_url=stream_url,
         stream_type=SUSI_STREAM_TYPE,
         transcription=_provider_config(transcription_provider),
-        translation=_provider_config(translation_provider),
+        translation=_translation_config(
+            translation_provider,
+            source_language=source_language,
+            target_languages=target_languages,
+        ),
     )
     return tenant_id

--- a/interpretation/services.py
+++ b/interpretation/services.py
@@ -1,0 +1,38 @@
+"""Orchestration helpers that drive the SUSI client for a room session."""
+
+from __future__ import annotations
+
+from .utils import SUSI_STREAM_TYPE
+
+
+def _provider_config(provider_name: str):
+    return {"provider_name": provider_name} if provider_name else None
+
+
+def start_stream_session(
+    client,
+    stream_url: str,
+    *,
+    transcription_provider: str = "",
+    translation_provider: str = "",
+) -> str:
+    """Create a SUSI session and configure it to ingest ``stream_url``.
+
+    All Eventyay stream URLs are sent through SUSI's ``youtube`` source
+    (``YouTubeSource``), which handles YouTube, Twitch, Vimeo, and HLS via
+    yt-dlp / ffmpeg.
+
+    Returns the SUSI tenant/session id. Raises ``SusiError`` on failure.
+    """
+    if not stream_url:
+        raise ValueError("stream_url is required to start a session")
+
+    tenant_id = client.create_session(source=SUSI_STREAM_TYPE)
+    client.configure(
+        tenant_id,
+        stream_url=stream_url,
+        stream_type=SUSI_STREAM_TYPE,
+        transcription=_provider_config(transcription_provider),
+        translation=_provider_config(translation_provider),
+    )
+    return tenant_id

--- a/interpretation/settings.py
+++ b/interpretation/settings.py
@@ -12,6 +12,9 @@ SETTING_SUSI_EMAIL = "interpretation_susi_email"
 SETTING_SUSI_NAME = "interpretation_susi_name"
 SETTING_IS_ENABLED = "interpretation_is_enabled"
 
+INTERPRETER_NONE = "none"
+INTERPRETER_SUSI = "susi"
+
 
 def get_base_url(event: Event) -> str:
     return event.settings.get(SETTING_BASE_URL, default="", as_type=str)
@@ -33,8 +36,12 @@ def is_interpretation_enabled(event: Event) -> bool:
     return event.settings.get(SETTING_IS_ENABLED, default=True, as_type=bool)
 
 
-def is_susi_configured(event: Event) -> bool:
+def is_susi_connected(event: Event) -> bool:
     return bool(get_base_url(event) and get_auth_token(event))
+
+
+def is_susi_configured(event: Event) -> bool:
+    return bool(is_interpretation_enabled(event) and is_susi_connected(event))
 
 
 def save_susi_connection(

--- a/interpretation/settings.py
+++ b/interpretation/settings.py
@@ -51,6 +51,9 @@ def save_susi_connection(
 
 
 def disconnect_susi(event: Event) -> None:
+    from .room_control import stop_all_event_sessions
+
+    stop_all_event_sessions(event)
     event.settings.set(SETTING_AUTH_TOKEN, "")
     event.settings.set(SETTING_SUSI_EMAIL, "")
     event.settings.set(SETTING_SUSI_NAME, "")

--- a/interpretation/settings.py
+++ b/interpretation/settings.py
@@ -12,9 +12,6 @@ SETTING_SUSI_EMAIL = "interpretation_susi_email"
 SETTING_SUSI_NAME = "interpretation_susi_name"
 SETTING_IS_ENABLED = "interpretation_is_enabled"
 
-INTERPRETER_NONE = "none"
-INTERPRETER_SUSI = "susi"
-
 
 def get_base_url(event: Event) -> str:
     return event.settings.get(SETTING_BASE_URL, default="", as_type=str)
@@ -41,7 +38,8 @@ def is_susi_connected(event: Event) -> bool:
 
 
 def is_susi_configured(event: Event) -> bool:
-    return bool(is_interpretation_enabled(event) and is_susi_connected(event))
+    """Whether SUSI credentials are available for rooms that select SUSI."""
+    return is_susi_connected(event)
 
 
 def save_susi_connection(

--- a/interpretation/susi.py
+++ b/interpretation/susi.py
@@ -150,7 +150,7 @@ class SusiClient:
 
     # -- session lifecycle (used by later milestones) -------------------
 
-    def create_session(self, source: str = "url") -> str:
+    def create_session(self, source: str = "youtube") -> str:
         """Mint a tenant/session ID for a given audio source."""
         result = self._request("POST", "/session", json={"source": source})
         if not result.ok:
@@ -165,7 +165,7 @@ class SusiClient:
         tenant_id: str,
         *,
         stream_url: str = "",
-        source_type: str = "url",
+        stream_type: str = "youtube",
         transcription: dict | None = None,
         translation: dict | None = None,
     ) -> SusiResult:
@@ -177,7 +177,8 @@ class SusiClient:
             payload["translation"] = translation
         if stream_url:
             payload["stream_url"] = stream_url
-            payload["source_type"] = source_type
+            # SUSI reads ``stream_type`` (defaults to ``youtube`` if omitted).
+            payload["stream_type"] = stream_type
         result = self._request("POST", "/api/v1/translate/configure", json=payload)
         if not result.ok:
             raise SusiError(f"Failed to configure SUSI tenant: {result.data}")
@@ -190,3 +191,8 @@ class SusiClient:
     def stop_session(self, tenant_id: str) -> SusiResult:
         """Stop the grabber and release resources for a tenant."""
         return self._request("POST", f"/stop_event/{tenant_id}")
+
+    def latest_transcript(self, tenant_id: str, sentences: bool = True) -> SusiResult:
+        """Fetch the most recent transcript for a tenant (non-destructive)."""
+        params = {"tenant_id": tenant_id, "sentences": "true" if sentences else "false"}
+        return self._request("GET", "/transcripts/latest", params=params)

--- a/interpretation/utils.py
+++ b/interpretation/utils.py
@@ -1,0 +1,136 @@
+"""Resolve the stream URL Eventyay exposes for a room."""
+
+from __future__ import annotations
+
+NATIVE_LIVESTREAM = "livestream.native"
+YOUTUBE_LIVESTREAM = "livestream.youtube"
+IFRAME_LIVESTREAM = "livestream.iframe"
+
+# SUSI ``YouTubeSource``: yt-dlp for platform URLs, ffmpeg for direct ``.m3u8``.
+SUSI_STREAM_TYPE = "youtube"
+
+# Embed-only schedules have no direct audio URL for SUSI to ingest.
+_SKIP_SCHEDULE_TYPES = frozenset({"iframe"})
+
+
+def _strip(url: str) -> str:
+    return (url or "").strip()
+
+
+def _youtube_url(value: str) -> str:
+    value = _strip(value)
+    if not value:
+        return ""
+    if "://" in value:
+        return value
+    return f"https://www.youtube.com/watch?v={value}"
+
+
+def _url_from_module(module: dict) -> str:
+    module_type = module.get("type")
+    config = module.get("config") or {}
+    if module_type == NATIVE_LIVESTREAM:
+        return _strip(config.get("hls_url"))
+    if module_type == YOUTUBE_LIVESTREAM:
+        return _youtube_url(config.get("ytid", ""))
+    if module_type == IFRAME_LIVESTREAM:
+        return _strip(config.get("url"))
+    return ""
+
+
+def get_module_stream_url(room) -> str:
+    """URL from the room's stage module (native HLS, YouTube, or iframe player)."""
+    for module in room.module_config or []:
+        if not isinstance(module, dict):
+            continue
+        url = _url_from_module(module)
+        if url:
+            return url
+    return ""
+
+
+def _schedules(room):
+    schedules = getattr(room, "stream_schedules", None)
+    if schedules is None:
+        return None
+    if hasattr(schedules, "exclude"):
+        return schedules.exclude(stream_type__in=_SKIP_SCHEDULE_TYPES)
+    return schedules
+
+
+def get_schedule_stream_url(room, at_time=None) -> str:
+    """URL from timed stream schedules (YouTube, Vimeo, HLS, native, …)."""
+    schedules = _schedules(room)
+    if schedules is None:
+        return ""
+
+    items = list(schedules)
+    active = [s for s in items if s.is_active(at_time) and _strip(s.url)]
+    if active:
+        return _strip(active[0].url)
+
+    dated = [s for s in items if _strip(s.url)]
+    if not dated:
+        return ""
+    latest = max(dated, key=lambda s: s.start_time)
+    return _strip(latest.url)
+
+
+def get_room_stream_url(room, at_time=None) -> str:
+    """Best stream URL for a room: stage module first, then stream schedule."""
+    return get_module_stream_url(room) or get_schedule_stream_url(room, at_time)
+
+
+def interpretation_dashboard_url(organizer_slug: str, event_slug: str) -> str:
+    from django.urls import reverse
+
+    return reverse(
+        "plugins:interpretation:dashboard",
+        kwargs={"organizer": organizer_slug, "event": event_slug},
+    )
+
+
+def room_settings_resume_path(room_id: int) -> str:
+    return f"video/admin/rooms/{room_id}"
+
+
+def normalize_target_languages(value) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw = value
+    elif isinstance(value, list):
+        if value and all(isinstance(item, str) for item in value):
+            if len(value) == 1 and "," in value[0]:
+                raw = value[0]
+            else:
+                codes = []
+                seen = set()
+                for code in value:
+                    code = (code or "").strip()
+                    if code and code not in seen:
+                        seen.add(code)
+                        codes.append(code)
+                return codes
+        raw = ",".join(str(item) for item in value)
+    else:
+        raw = str(value)
+    codes = []
+    seen = set()
+    for code in raw.split(","):
+        code = code.strip()
+        if code and code not in seen:
+            seen.add(code)
+            codes.append(code)
+    return codes
+
+
+def room_settings_url(organizer_slug: str, event_slug: str, room_id: int) -> str:
+    """Commons link that opens the video room editor for interpretation settings."""
+    from django.urls import reverse
+
+    base = reverse(
+        "eventyay_common:event.create_access_to_video",
+        kwargs={"organizer": organizer_slug, "event": event_slug},
+    )
+    return f"{base}?resume_path={room_settings_resume_path(room_id)}"

--- a/interpretation/utils.py
+++ b/interpretation/utils.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
+import json
+
+from django.utils.translation import gettext_lazy as _
+
+MAX_BACKEND_CONFIG_KEYS = 32
+MAX_BACKEND_CONFIG_BYTES = 8192
+MAX_TARGET_LANGUAGES = 32
+MAX_LANGUAGE_CODE_LEN = 20
+
 NATIVE_LIVESTREAM = "livestream.native"
 YOUTUBE_LIVESTREAM = "livestream.youtube"
 IFRAME_LIVESTREAM = "livestream.iframe"
@@ -92,6 +101,40 @@ def interpretation_dashboard_url(organizer_slug: str, event_slug: str) -> str:
 
 def room_settings_resume_path(room_id: int) -> str:
     return f"video/admin/rooms/{room_id}"
+
+
+def validate_backend_config(value) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError(_("backend_config must be an object."))
+    if len(value) > MAX_BACKEND_CONFIG_KEYS:
+        raise ValueError(
+            _("backend_config has too many keys (max %(max)d).")
+            % {"max": MAX_BACKEND_CONFIG_KEYS}
+        )
+    try:
+        encoded = json.dumps(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(_("backend_config is not valid JSON.")) from exc
+    if len(encoded) > MAX_BACKEND_CONFIG_BYTES:
+        raise ValueError(
+            _("backend_config is too large (max %(max)d bytes).")
+            % {"max": MAX_BACKEND_CONFIG_BYTES}
+        )
+    return dict(value)
+
+
+def validate_target_language_codes(codes: list[str]) -> list[str]:
+    if len(codes) > MAX_TARGET_LANGUAGES:
+        raise ValueError(
+            _("Too many target languages (max %(max)d).")
+            % {"max": MAX_TARGET_LANGUAGES}
+        )
+    for code in codes:
+        if len(code) > MAX_LANGUAGE_CODE_LEN:
+            raise ValueError(
+                _("Language code too long: %(code)s") % {"code": code[:32]}
+            )
+    return codes
 
 
 def normalize_target_languages(value) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,5 +94,4 @@ def connected_event(event):
 def connection_payload():
     return {
         "interpretation-interpretation_base_url": "https://susi.example.com",
-        "interpretation-interpretation_is_enabled": "on",
     }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -8,7 +8,6 @@ from interpretation.forms import TEST_POST_KEY
 from interpretation.settings import (
     get_auth_token,
     get_base_url,
-    is_interpretation_enabled,
 )
 from interpretation.susi import SusiResult
 
@@ -26,7 +25,6 @@ def test_save_persists_connection(
     connected_event.settings.flush()
     assert get_base_url(connected_event) == "https://susi.example.com"
     assert get_auth_token(connected_event) == "jwt-test-token"
-    assert is_interpretation_enabled(connected_event) is True
 
     messages = [str(message) for message in get_messages(response.wsgi_request)]
     assert any("saved" in message.lower() for message in messages)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,14 +1,14 @@
-"""Tests for InterpretationSettingsForm validation and connect flow."""
+"""Tests for InterpretationSettingsForm and RoomInterpretationForm."""
 
 from interpretation.forms import (
     CONNECT_POST_KEY,
     InterpretationSettingsForm,
     RoomInterpretationForm,
 )
+from interpretation.models import RoomInterpretation
 from interpretation.settings import (
     SETTING_AUTH_TOKEN,
     SETTING_BASE_URL,
-    SETTING_IS_ENABLED,
     SETTING_SUSI_EMAIL,
 )
 
@@ -18,7 +18,6 @@ PUBLIC_URL = "https://example.com"
 _SETTING_TYPES = {
     SETTING_BASE_URL: str,
     SETTING_AUTH_TOKEN: str,
-    SETTING_IS_ENABLED: bool,
 }
 
 
@@ -71,36 +70,9 @@ def _form(data, settings=None, prefix="interpretation"):
 
 
 def test_base_url_trailing_slash_is_stripped():
-    form = _form(
-        {
-            SETTING_BASE_URL: f"{PUBLIC_URL}/",
-            SETTING_IS_ENABLED: False,
-        }
-    )
+    form = _form({SETTING_BASE_URL: f"{PUBLIC_URL}/"})
     assert form.is_valid(), form.errors
     assert form.cleaned_data[SETTING_BASE_URL] == PUBLIC_URL
-
-
-def test_enabling_without_connection_is_rejected():
-    form = _form(
-        {
-            SETTING_BASE_URL: PUBLIC_URL,
-            SETTING_IS_ENABLED: True,
-        }
-    )
-    assert not form.is_valid()
-    assert SETTING_IS_ENABLED in form.errors
-
-
-def test_enabling_with_existing_token_is_accepted():
-    form = _form(
-        {
-            SETTING_BASE_URL: PUBLIC_URL,
-            SETTING_IS_ENABLED: True,
-        },
-        settings={SETTING_AUTH_TOKEN: "stored-token"},
-    )
-    assert form.is_valid(), form.errors
 
 
 def test_connect_requires_email_and_password():
@@ -147,7 +119,7 @@ def test_connect_with_credentials_is_valid(monkeypatch):
     assert form.obj.settings.get(SETTING_SUSI_EMAIL) == "bot@example.com"
 
 
-def test_failed_connect_does_not_enable_interpretation(monkeypatch):
+def test_failed_connect_does_not_store_token(monkeypatch):
     from django.contrib import messages
 
     from interpretation.susi import SusiError
@@ -164,43 +136,13 @@ def test_failed_connect_does_not_enable_interpretation(monkeypatch):
             SETTING_BASE_URL: PUBLIC_URL,
             "susi_connect_email": "bot@example.com",
             "susi_connect_password": "wrong",
-            SETTING_IS_ENABLED: True,
             CONNECT_POST_KEY: "1",
         }
     )
     assert form.is_valid(), form.errors
     form.save_pending_connect()
     form.run_connect_action(request=type("R", (), {})())
-    enabled = form.obj.settings.get(SETTING_IS_ENABLED, default=False, as_type=bool)
-    assert enabled is False
     assert not form.obj.settings.get(SETTING_AUTH_TOKEN)
-
-
-def test_successful_connect_with_enable_sets_enabled_flag(monkeypatch):
-    from django.contrib import messages
-
-    from interpretation.susi import SusiLoginResult
-
-    monkeypatch.setattr(messages, "success", lambda *a, **k: None)
-    monkeypatch.setattr(messages, "error", lambda *a, **k: None)
-
-    def fake_login(self, email, password):
-        return SusiLoginResult(token="jwt", email=email, name="Bot")
-
-    monkeypatch.setattr("interpretation.forms.SusiClient.login", fake_login)
-    form = _form(
-        {
-            SETTING_BASE_URL: PUBLIC_URL,
-            "susi_connect_email": "bot@example.com",
-            "susi_connect_password": "secret",
-            SETTING_IS_ENABLED: True,
-            CONNECT_POST_KEY: "1",
-        }
-    )
-    assert form.is_valid(), form.errors
-    form.save_pending_connect()
-    form.run_connect_action(request=type("R", (), {})())
-    assert form.obj.settings.get(SETTING_IS_ENABLED, as_type=bool) is True
 
 
 def test_save_does_not_persist_connect_credentials():
@@ -209,7 +151,6 @@ def test_save_does_not_persist_connect_credentials():
             SETTING_BASE_URL: PUBLIC_URL,
             "susi_connect_email": "bot@example.com",
             "susi_connect_password": "secret",
-            SETTING_IS_ENABLED: False,
         },
     )
     assert form.is_valid(), form.errors
@@ -223,6 +164,8 @@ def test_save_does_not_persist_connect_credentials():
 def test_room_form_parses_comma_separated_languages():
     form = RoomInterpretationForm(
         data={
+            "interpreter": RoomInterpretation.INTERPRETER_NONE,
+            "room_enabled": False,
             "stream_url": "https://stream.example.com/r.m3u8",
             "target_languages": "de, fr ,es",
             "transcription_provider": "",
@@ -236,6 +179,8 @@ def test_room_form_parses_comma_separated_languages():
 def test_room_form_deduplicates_languages():
     form = RoomInterpretationForm(
         data={
+            "interpreter": RoomInterpretation.INTERPRETER_NONE,
+            "room_enabled": False,
             "stream_url": "",
             "target_languages": "de, de, fr",
             "transcription_provider": "",
@@ -249,6 +194,8 @@ def test_room_form_deduplicates_languages():
 def test_room_form_empty_languages_is_empty_list():
     form = RoomInterpretationForm(
         data={
+            "interpreter": RoomInterpretation.INTERPRETER_NONE,
+            "room_enabled": False,
             "stream_url": "",
             "target_languages": "",
             "transcription_provider": "",

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -174,6 +174,32 @@ def test_save_does_not_persist_connect_credentials():
     assert stored.get(SETTING_BASE_URL) == PUBLIC_URL
 
 
+def test_save_disabling_event_stops_sessions(monkeypatch):
+    stopped = []
+
+    def fake_stop_all(event):
+        stopped.append(event)
+
+    monkeypatch.setattr(
+        "interpretation.room_control.stop_all_event_sessions",
+        fake_stop_all,
+    )
+    form = _form(
+        {
+            SETTING_BASE_URL: PUBLIC_URL,
+            SETTING_IS_ENABLED: False,
+        },
+        settings={
+            SETTING_BASE_URL: PUBLIC_URL,
+            SETTING_AUTH_TOKEN: "tok",
+            SETTING_IS_ENABLED: True,
+        },
+    )
+    assert form.is_valid(), form.errors
+    form.save()
+    assert stopped == [form.obj]
+
+
 def test_room_form_parses_comma_separated_languages():
     form = RoomInterpretationForm(
         data={

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -9,6 +9,7 @@ from interpretation.models import RoomInterpretation
 from interpretation.settings import (
     SETTING_AUTH_TOKEN,
     SETTING_BASE_URL,
+    SETTING_IS_ENABLED,
     SETTING_SUSI_EMAIL,
 )
 
@@ -18,6 +19,7 @@ PUBLIC_URL = "https://example.com"
 _SETTING_TYPES = {
     SETTING_BASE_URL: str,
     SETTING_AUTH_TOKEN: str,
+    SETTING_IS_ENABLED: bool,
 }
 
 
@@ -87,6 +89,17 @@ def test_connect_requires_email_and_password():
     assert not form.is_valid()
     assert "susi_connect_email" in form.errors
     assert "susi_connect_password" in form.errors
+
+
+def test_enable_without_susi_connection_is_rejected():
+    form = _form(
+        {
+            SETTING_BASE_URL: PUBLIC_URL,
+            SETTING_IS_ENABLED: True,
+        }
+    )
+    assert not form.is_valid()
+    assert SETTING_IS_ENABLED in form.errors
 
 
 def test_connect_with_credentials_is_valid(monkeypatch):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,6 +1,10 @@
 """Tests for InterpretationSettingsForm validation and connect flow."""
 
-from interpretation.forms import CONNECT_POST_KEY, InterpretationSettingsForm
+from interpretation.forms import (
+    CONNECT_POST_KEY,
+    InterpretationSettingsForm,
+    RoomInterpretationForm,
+)
 from interpretation.settings import (
     SETTING_AUTH_TOKEN,
     SETTING_BASE_URL,
@@ -214,3 +218,42 @@ def test_save_does_not_persist_connect_credentials():
     assert "susi_connect_password" not in stored
     assert "susi_connect_email" not in stored
     assert stored.get(SETTING_BASE_URL) == PUBLIC_URL
+
+
+def test_room_form_parses_comma_separated_languages():
+    form = RoomInterpretationForm(
+        data={
+            "stream_url": "https://stream.example.com/r.m3u8",
+            "target_languages": "de, fr ,es",
+            "transcription_provider": "",
+            "translation_provider": "",
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["target_languages"] == ["de", "fr", "es"]
+
+
+def test_room_form_deduplicates_languages():
+    form = RoomInterpretationForm(
+        data={
+            "stream_url": "",
+            "target_languages": "de, de, fr",
+            "transcription_provider": "",
+            "translation_provider": "",
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["target_languages"] == ["de", "fr"]
+
+
+def test_room_form_empty_languages_is_empty_list():
+    form = RoomInterpretationForm(
+        data={
+            "stream_url": "",
+            "target_languages": "",
+            "transcription_provider": "",
+            "translation_provider": "",
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["target_languages"] == []

--- a/tests/test_room_control.py
+++ b/tests/test_room_control.py
@@ -1,0 +1,14 @@
+from interpretation.utils import normalize_target_languages
+
+
+def test_normalize_target_languages_from_comma_string():
+    assert normalize_target_languages("de, fr, de, es") == ["de", "fr", "es"]
+
+
+def test_normalize_target_languages_from_list():
+    assert normalize_target_languages(["de", "fr"]) == ["de", "fr"]
+
+
+def test_normalize_target_languages_empty():
+    assert normalize_target_languages("") == []
+    assert normalize_target_languages([]) == []

--- a/tests/test_room_control.py
+++ b/tests/test_room_control.py
@@ -1,4 +1,12 @@
-from interpretation.utils import normalize_target_languages
+import pytest
+
+from interpretation.utils import (
+    MAX_BACKEND_CONFIG_BYTES,
+    MAX_TARGET_LANGUAGES,
+    normalize_target_languages,
+    validate_backend_config,
+    validate_target_language_codes,
+)
 
 
 def test_normalize_target_languages_from_comma_string():
@@ -12,3 +20,46 @@ def test_normalize_target_languages_from_list():
 def test_normalize_target_languages_empty():
     assert normalize_target_languages("") == []
     assert normalize_target_languages([]) == []
+
+
+def test_validate_backend_config_rejects_non_object():
+    with pytest.raises(ValueError, match="object"):
+        validate_backend_config(["bad"])
+
+
+def test_validate_backend_config_rejects_oversized_payload():
+    huge = {"k": "x" * (MAX_BACKEND_CONFIG_BYTES + 1)}
+    with pytest.raises(ValueError, match="too large"):
+        validate_backend_config(huge)
+
+
+def test_validate_target_language_codes_rejects_too_many():
+    codes = [f"l{i}" for i in range(MAX_TARGET_LANGUAGES + 1)]
+    with pytest.raises(ValueError, match="Too many"):
+        validate_target_language_codes(codes)
+
+
+def test_disconnect_susi_stops_event_sessions(monkeypatch):
+    from interpretation.settings import disconnect_susi
+
+    stopped = []
+
+    def fake_stop_all(event):
+        stopped.append(event)
+
+    monkeypatch.setattr(
+        "interpretation.room_control.stop_all_event_sessions",
+        fake_stop_all,
+    )
+
+    class _FakeSettings:
+        def __init__(self):
+            self.data = {}
+
+        def set(self, key, value):
+            self.data[key] = value
+
+    event = type("E", (), {"settings": _FakeSettings()})()
+    disconnect_susi(event)
+    assert stopped == [event]
+    assert event.settings.data["interpretation_auth_token"] == ""

--- a/tests/test_room_interpreter.py
+++ b/tests/test_room_interpreter.py
@@ -51,12 +51,15 @@ class _FakeInterpretation:
         self.interpreter = kwargs.get("interpreter", INTERPRETER_NONE)
         self.room_enabled = kwargs.get("room_enabled", False)
         self.stream_url = kwargs.get("stream_url", "")
+        self.source_language = kwargs.get("source_language", "")
         self.target_languages = kwargs.get("target_languages", [])
         self.transcription_provider = ""
         self.translation_provider = ""
         self.backend_config = {}
         self.backend_session_id = kwargs.get("backend_session_id", "")
-        self.status = RoomInterpretation.STATUS_IDLE
+        self.status = kwargs.get(
+            "status", RoomInterpretation.STATUS_IDLE
+        )
         self.saved = 0
 
     def save(self, update_fields=None):
@@ -155,6 +158,47 @@ def test_start_room_session_uses_selected_backend(monkeypatch):
     assert calls == ["https://x/r.m3u8"]
     assert interpretation.backend_session_id == "tenant-42"
     assert interpretation.status == RoomInterpretation.STATUS_RUNNING
+
+
+def test_start_room_session_is_idempotent_when_already_running(monkeypatch):
+    event = _FakeEvent(
+        {
+            "interpretation_base_url": "https://susi.example.com",
+            "interpretation_auth_token": "tok",
+        }
+    )
+    interpretation = _FakeInterpretation(
+        room_enabled=True,
+        interpreter=INTERPRETER_SUSI,
+        backend_session_id="tenant-1",
+        status=RoomInterpretation.STATUS_RUNNING,
+    )
+    calls = []
+
+    class FakeBackend:
+        id = INTERPRETER_SUSI
+        label = "SUSI"
+
+        def is_configured(self, event):
+            return True
+
+        def start(self, event, interpretation, *, stream_url):
+            calls.append(stream_url)
+            return "tenant-2"
+
+    monkeypatch.setattr(
+        "interpretation.room_control.RoomInterpretation.objects.get_or_create",
+        lambda room: (interpretation, False),
+    )
+    monkeypatch.setattr(
+        "interpretation.room_control.get_backend",
+        lambda interpreter_id: FakeBackend(),
+    )
+
+    result = start_room_session(_FakeRoom(), event)
+    assert result.ok
+    assert calls == []
+    assert interpretation.backend_session_id == "tenant-1"
 
 
 def test_update_room_interpretation_rejects_unconfigured_interpreter(monkeypatch):

--- a/tests/test_room_interpreter.py
+++ b/tests/test_room_interpreter.py
@@ -66,6 +66,9 @@ class _FakeInterpretation:
     def save(self, update_fields=None):
         self.saved += 1
 
+    def refresh_from_db(self, using=None, fields=None):
+        return None
+
 
 def test_get_backend_defaults_to_none():
     backend = get_backend("unknown")

--- a/tests/test_room_interpreter.py
+++ b/tests/test_room_interpreter.py
@@ -7,6 +7,7 @@ from interpretation.models import RoomInterpretation
 from interpretation.room_control import (
     is_room_interpretation_ready,
     normalize_session_status,
+    serialize_room_interpretation,
     start_room_session,
     stop_room_session,
     update_room_interpretation,
@@ -78,6 +79,30 @@ def test_normalize_session_status_maps_legacy_values():
     assert normalize_session_status(RoomInterpretation.STATUS_IDLE) == "idle"
     assert normalize_session_status(RoomInterpretation.STATUS_STOPPED) == "idle"
     assert normalize_session_status(RoomInterpretation.STATUS_ERROR) == "idle"
+
+
+def test_serialize_hides_session_id_when_not_running():
+    event = _FakeEvent()
+    interpretation = _FakeInterpretation(
+        interpreter=INTERPRETER_SUSI,
+        backend_session_id="tenant-stale",
+        status=RoomInterpretation.STATUS_IDLE,
+    )
+    data = serialize_room_interpretation(_FakeRoom(), event, interpretation)
+    assert data["status"] == "idle"
+    assert data["session_id"] == ""
+
+
+def test_serialize_includes_session_id_when_running():
+    event = _FakeEvent()
+    interpretation = _FakeInterpretation(
+        interpreter=INTERPRETER_SUSI,
+        backend_session_id="tenant-live",
+        status=RoomInterpretation.STATUS_RUNNING,
+    )
+    data = serialize_room_interpretation(_FakeRoom(), event, interpretation)
+    assert data["status"] == "running"
+    assert data["session_id"] == "tenant-live"
 
 
 def test_is_room_interpretation_ready_requires_enabled_interpreter_and_credentials():
@@ -225,6 +250,44 @@ def test_start_room_session_is_idempotent_when_already_running(monkeypatch):
     assert interpretation.backend_session_id == "tenant-1"
 
 
+def test_start_room_session_clears_stale_session_id_on_failure(monkeypatch):
+    event = _FakeEvent(
+        {
+            "interpretation_base_url": "https://susi.example.com",
+            "interpretation_auth_token": "tok",
+        }
+    )
+    interpretation = _FakeInterpretation(
+        room_enabled=True,
+        interpreter=INTERPRETER_SUSI,
+        backend_session_id="tenant-old",
+        status=RoomInterpretation.STATUS_IDLE,
+    )
+
+    class FakeBackend:
+        def is_configured(self, event):
+            return True
+
+        def start(self, event, interpretation, *, stream_url):
+            from interpretation.susi import SusiError
+
+            raise SusiError("configure failed")
+
+    monkeypatch.setattr(
+        "interpretation.room_control.RoomInterpretation.objects.get_or_create",
+        lambda room: (interpretation, False),
+    )
+    monkeypatch.setattr(
+        "interpretation.room_control.get_backend",
+        lambda interpreter_id: FakeBackend(),
+    )
+
+    result = start_room_session(_FakeRoom(), event)
+    assert not result.ok
+    assert interpretation.backend_session_id == ""
+    assert interpretation.status == RoomInterpretation.STATUS_IDLE
+
+
 def test_stop_room_session_clears_local_state_when_remote_stop_fails(monkeypatch):
     event = _FakeEvent(
         {
@@ -258,6 +321,41 @@ def test_stop_room_session_clears_local_state_when_remote_stop_fails(monkeypatch
     assert not result.ok
     assert interpretation.status == RoomInterpretation.STATUS_IDLE
     assert interpretation.backend_session_id == ""
+
+
+def test_update_room_interpretation_raises_when_auto_stop_fails(monkeypatch):
+    event = _FakeEvent(
+        {
+            "interpretation_base_url": "https://susi.example.com",
+            "interpretation_auth_token": "tok",
+        }
+    )
+    interpretation = _FakeInterpretation(
+        room_enabled=True,
+        interpreter=INTERPRETER_SUSI,
+        backend_session_id="tenant-1",
+        status=RoomInterpretation.STATUS_RUNNING,
+    )
+
+    monkeypatch.setattr(
+        "interpretation.room_control.RoomInterpretation.objects.get_or_create",
+        lambda room: (interpretation, False),
+    )
+    monkeypatch.setattr(
+        "interpretation.room_control.stop_room_session",
+        lambda room, event: type(
+            "R",
+            (),
+            {"ok": False, "error": "SUSI unreachable", "interpretation": interpretation},
+        )(),
+    )
+
+    with pytest.raises(ValueError, match="SUSI unreachable"):
+        update_room_interpretation(
+            _FakeRoom(),
+            event,
+            {"interpreter": INTERPRETER_NONE},
+        )
 
 
 def test_update_room_interpretation_rejects_unconfigured_interpreter(monkeypatch):

--- a/tests/test_room_interpreter.py
+++ b/tests/test_room_interpreter.py
@@ -60,9 +60,7 @@ class _FakeInterpretation:
         self.translation_provider = ""
         self.backend_config = {}
         self.backend_session_id = kwargs.get("backend_session_id", "")
-        self.status = kwargs.get(
-            "status", RoomInterpretation.STATUS_IDLE
-        )
+        self.status = kwargs.get("status", RoomInterpretation.STATUS_IDLE)
         self.saved = 0
 
     def save(self, update_fields=None):

--- a/tests/test_room_interpreter.py
+++ b/tests/test_room_interpreter.py
@@ -1,0 +1,172 @@
+"""Tests for per-room interpreter dispatch and readiness."""
+
+import pytest
+
+from interpretation.backends import INTERPRETER_NONE, INTERPRETER_SUSI, get_backend
+from interpretation.models import RoomInterpretation
+from interpretation.room_control import (
+    is_room_interpretation_ready,
+    start_room_session,
+    update_room_interpretation,
+)
+
+
+class _FakeSettings:
+    def __init__(self, data=None):
+        self._data = dict(data or {})
+
+    def get(self, key, default=None, as_type=str):
+        if key not in self._data:
+            return default
+        value = self._data[key]
+        if as_type is bool:
+            return bool(value)
+        return as_type(value)
+
+    def set(self, key, value):
+        self._data[key] = value
+
+
+class _FakeEvent:
+    def __init__(self, settings=None, plugins=None):
+        self.settings = _FakeSettings(settings)
+        self.organizer = type("O", (), {"slug": "org"})()
+        self.slug = "evt"
+
+    def get_plugins(self):
+        return ["interpretation"]
+
+
+class _FakeRoom:
+    pk = 1
+    module_config = [
+        {"type": "livestream.native", "config": {"hls_url": "https://x/r.m3u8"}}
+    ]
+    stream_schedules = None
+
+
+class _FakeInterpretation:
+    def __init__(self, **kwargs):
+        self.room = _FakeRoom()
+        self.interpreter = kwargs.get("interpreter", INTERPRETER_NONE)
+        self.room_enabled = kwargs.get("room_enabled", False)
+        self.stream_url = kwargs.get("stream_url", "")
+        self.target_languages = kwargs.get("target_languages", [])
+        self.transcription_provider = ""
+        self.translation_provider = ""
+        self.backend_config = {}
+        self.backend_session_id = kwargs.get("backend_session_id", "")
+        self.status = RoomInterpretation.STATUS_IDLE
+        self.saved = 0
+
+    def save(self, update_fields=None):
+        self.saved += 1
+
+
+def test_get_backend_defaults_to_none():
+    backend = get_backend("unknown")
+    assert backend.id == INTERPRETER_NONE
+
+
+def test_is_room_interpretation_ready_requires_enabled_interpreter_and_credentials():
+    event = _FakeEvent(
+        {
+            "interpretation_base_url": "https://susi.example.com",
+            "interpretation_auth_token": "tok",
+        }
+    )
+    off = _FakeInterpretation(room_enabled=False, interpreter=INTERPRETER_SUSI)
+    assert is_room_interpretation_ready(_FakeRoom(), event, off) is False
+
+    none = _FakeInterpretation(room_enabled=True, interpreter=INTERPRETER_NONE)
+    assert is_room_interpretation_ready(_FakeRoom(), event, none) is False
+
+    ready = _FakeInterpretation(room_enabled=True, interpreter=INTERPRETER_SUSI)
+    assert is_room_interpretation_ready(_FakeRoom(), event, ready) is True
+
+    no_creds = _FakeEvent()
+    assert is_room_interpretation_ready(_FakeRoom(), no_creds, ready) is False
+
+
+def test_start_room_session_rejects_disabled_room(monkeypatch):
+    interpretation = _FakeInterpretation(
+        room_enabled=False, interpreter=INTERPRETER_SUSI
+    )
+
+    def fake_get_or_create(room):
+        return interpretation, False
+
+    monkeypatch.setattr(
+        "interpretation.room_control.RoomInterpretation.objects.get_or_create",
+        lambda room: fake_get_or_create(room),
+    )
+    result = start_room_session(_FakeRoom(), _FakeEvent())
+    assert not result.ok
+    assert "disabled" in result.error.lower()
+
+
+def test_start_room_session_rejects_missing_interpreter(monkeypatch):
+    interpretation = _FakeInterpretation(room_enabled=True, interpreter=INTERPRETER_NONE)
+
+    monkeypatch.setattr(
+        "interpretation.room_control.RoomInterpretation.objects.get_or_create",
+        lambda room: (interpretation, False),
+    )
+    result = start_room_session(_FakeRoom(), _FakeEvent())
+    assert not result.ok
+    assert "interpreter" in result.error.lower()
+
+
+def test_start_room_session_uses_selected_backend(monkeypatch):
+    event = _FakeEvent(
+        {
+            "interpretation_base_url": "https://susi.example.com",
+            "interpretation_auth_token": "tok",
+        }
+    )
+    interpretation = _FakeInterpretation(
+        room_enabled=True,
+        interpreter=INTERPRETER_SUSI,
+    )
+    calls = []
+
+    class FakeBackend:
+        id = INTERPRETER_SUSI
+        label = "SUSI"
+
+        def is_configured(self, event):
+            return True
+
+        def start(self, event, interpretation, *, stream_url):
+            calls.append(stream_url)
+            return "tenant-42"
+
+    monkeypatch.setattr(
+        "interpretation.room_control.RoomInterpretation.objects.get_or_create",
+        lambda room: (interpretation, False),
+    )
+    monkeypatch.setattr(
+        "interpretation.room_control.get_backend",
+        lambda interpreter_id: FakeBackend(),
+    )
+
+    result = start_room_session(_FakeRoom(), event)
+    assert result.ok
+    assert calls == ["https://x/r.m3u8"]
+    assert interpretation.backend_session_id == "tenant-42"
+    assert interpretation.status == RoomInterpretation.STATUS_RUNNING
+
+
+def test_update_room_interpretation_rejects_unconfigured_interpreter(monkeypatch):
+    event = _FakeEvent()
+    interpretation = _FakeInterpretation()
+
+    monkeypatch.setattr(
+        "interpretation.room_control.RoomInterpretation.objects.get_or_create",
+        lambda room: (interpretation, True),
+    )
+
+    with pytest.raises(ValueError, match="Connect"):
+        update_room_interpretation(
+            _FakeRoom(), event, {"interpreter": INTERPRETER_SUSI}
+        )

--- a/tests/test_room_interpreter.py
+++ b/tests/test_room_interpreter.py
@@ -91,6 +91,21 @@ def test_is_room_interpretation_ready_requires_enabled_interpreter_and_credentia
     assert is_room_interpretation_ready(_FakeRoom(), no_creds, ready) is False
 
 
+def test_start_room_session_rejects_disabled_event(monkeypatch):
+    event = _FakeEvent({"interpretation_is_enabled": False})
+    interpretation = _FakeInterpretation(
+        room_enabled=True, interpreter=INTERPRETER_SUSI
+    )
+
+    monkeypatch.setattr(
+        "interpretation.room_control.RoomInterpretation.objects.get_or_create",
+        lambda room: (interpretation, False),
+    )
+    result = start_room_session(_FakeRoom(), event)
+    assert not result.ok
+    assert "turned off" in result.error.lower()
+
+
 def test_start_room_session_rejects_disabled_room(monkeypatch):
     interpretation = _FakeInterpretation(
         room_enabled=False, interpreter=INTERPRETER_SUSI

--- a/tests/test_room_interpreter.py
+++ b/tests/test_room_interpreter.py
@@ -158,7 +158,9 @@ def test_start_room_session_rejects_disabled_room(monkeypatch):
 
 
 def test_start_room_session_rejects_missing_interpreter(monkeypatch):
-    interpretation = _FakeInterpretation(room_enabled=True, interpreter=INTERPRETER_NONE)
+    interpretation = _FakeInterpretation(
+        room_enabled=True, interpreter=INTERPRETER_NONE
+    )
 
     monkeypatch.setattr(
         "interpretation.room_control.RoomInterpretation.objects.get_or_create",
@@ -346,7 +348,11 @@ def test_update_room_interpretation_raises_when_auto_stop_fails(monkeypatch):
         lambda room, event: type(
             "R",
             (),
-            {"ok": False, "error": "SUSI unreachable", "interpretation": interpretation},
+            {
+                "ok": False,
+                "error": "SUSI unreachable",
+                "interpretation": interpretation,
+            },
         )(),
     )
 

--- a/tests/test_room_interpreter.py
+++ b/tests/test_room_interpreter.py
@@ -6,7 +6,9 @@ from interpretation.backends import INTERPRETER_NONE, INTERPRETER_SUSI, get_back
 from interpretation.models import RoomInterpretation
 from interpretation.room_control import (
     is_room_interpretation_ready,
+    normalize_session_status,
     start_room_session,
+    stop_room_session,
     update_room_interpretation,
 )
 
@@ -69,6 +71,13 @@ class _FakeInterpretation:
 def test_get_backend_defaults_to_none():
     backend = get_backend("unknown")
     assert backend.id == INTERPRETER_NONE
+
+
+def test_normalize_session_status_maps_legacy_values():
+    assert normalize_session_status(RoomInterpretation.STATUS_RUNNING) == "running"
+    assert normalize_session_status(RoomInterpretation.STATUS_IDLE) == "idle"
+    assert normalize_session_status(RoomInterpretation.STATUS_STOPPED) == "idle"
+    assert normalize_session_status(RoomInterpretation.STATUS_ERROR) == "idle"
 
 
 def test_is_room_interpretation_ready_requires_enabled_interpreter_and_credentials():
@@ -214,6 +223,41 @@ def test_start_room_session_is_idempotent_when_already_running(monkeypatch):
     assert result.ok
     assert calls == []
     assert interpretation.backend_session_id == "tenant-1"
+
+
+def test_stop_room_session_clears_local_state_when_remote_stop_fails(monkeypatch):
+    event = _FakeEvent(
+        {
+            "interpretation_base_url": "https://susi.example.com",
+            "interpretation_auth_token": "tok",
+        }
+    )
+    interpretation = _FakeInterpretation(
+        room_enabled=True,
+        interpreter=INTERPRETER_SUSI,
+        backend_session_id="tenant-1",
+        status=RoomInterpretation.STATUS_RUNNING,
+    )
+
+    class FakeBackend:
+        def stop(self, event, interpretation):
+            from interpretation.susi import SusiError
+
+            raise SusiError("SUSI unreachable")
+
+    monkeypatch.setattr(
+        "interpretation.room_control.get_interpretation",
+        lambda room: interpretation,
+    )
+    monkeypatch.setattr(
+        "interpretation.room_control.get_backend",
+        lambda interpreter_id: FakeBackend(),
+    )
+
+    result = stop_room_session(_FakeRoom(), event)
+    assert not result.ok
+    assert interpretation.status == RoomInterpretation.STATUS_IDLE
+    assert interpretation.backend_session_id == ""
 
 
 def test_update_room_interpretation_rejects_unconfigured_interpreter(monkeypatch):

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -1,0 +1,200 @@
+"""Tests for stream URL resolution and the start-session service."""
+
+import pytest
+
+from interpretation.services import start_stream_session
+from interpretation.utils import (
+    SUSI_STREAM_TYPE,
+    get_module_stream_url,
+    get_room_stream_url,
+    get_schedule_stream_url,
+    room_settings_resume_path,
+)
+
+
+class FakeRoom:
+    def __init__(self, module_config=None, schedules=None):
+        self.module_config = module_config
+        self.stream_schedules = FakeScheduleManager(schedules or [])
+
+
+class FakeSchedule:
+    def __init__(self, url, stream_type="hls", start_time=0, active=False):
+        self.url = url
+        self.stream_type = stream_type
+        self.start_time = start_time
+        self._active = active
+
+    def is_active(self, at_time=None):
+        return self._active
+
+
+class FakeScheduleManager:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def exclude(self, **kwargs):
+        skip = set(kwargs.get("stream_type__in", ()))
+        return FakeScheduleManager(
+            [s for s in self._items if s.stream_type not in skip]
+        )
+
+    def __iter__(self):
+        return iter(self._items)
+
+
+# -- module_config extraction ------------------------------------------
+
+
+def test_module_native_hls():
+    room = FakeRoom(
+        module_config=[
+            {"type": "chat.native", "config": {}},
+            {"type": "livestream.native", "config": {"hls_url": "https://x/r.m3u8"}},
+        ]
+    )
+    assert get_module_stream_url(room) == "https://x/r.m3u8"
+
+
+def test_module_youtube_id_normalized():
+    room = FakeRoom(
+        module_config=[
+            {"type": "livestream.youtube", "config": {"ytid": "dQw4w9WgXcQ"}},
+        ]
+    )
+    assert (
+        get_module_stream_url(room)
+        == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    )
+
+
+def test_module_youtube_url_passthrough():
+    room = FakeRoom(
+        module_config=[
+            {
+                "type": "livestream.youtube",
+                "config": {"ytid": "https://youtu.be/abc123"},
+            },
+        ]
+    )
+    assert get_module_stream_url(room) == "https://youtu.be/abc123"
+
+
+def test_module_absent_returns_empty():
+    room = FakeRoom(module_config=[{"type": "call.bigbluebutton", "config": {}}])
+    assert get_module_stream_url(room) == ""
+
+
+def test_module_handles_none_and_malformed():
+    assert get_module_stream_url(FakeRoom(module_config=None)) == ""
+    assert get_module_stream_url(FakeRoom(module_config=["not-a-dict"])) == ""
+
+
+# -- schedule extraction -----------------------------------------------
+
+
+def test_schedule_prefers_active():
+    room = FakeRoom(
+        schedules=[
+            FakeSchedule("https://old/x.m3u8", start_time=1, active=False),
+            FakeSchedule("https://live/x.m3u8", start_time=2, active=True),
+        ]
+    )
+    assert get_schedule_stream_url(room) == "https://live/x.m3u8"
+
+
+def test_schedule_falls_back_to_latest():
+    room = FakeRoom(
+        schedules=[
+            FakeSchedule("https://a/x.m3u8", start_time=1, active=False),
+            FakeSchedule("https://b/x.m3u8", start_time=5, active=False),
+        ]
+    )
+    assert get_schedule_stream_url(room) == "https://b/x.m3u8"
+
+
+def test_schedule_includes_youtube():
+    room = FakeRoom(
+        schedules=[FakeSchedule("https://youtu.be/abc", stream_type="youtube")]
+    )
+    assert get_schedule_stream_url(room) == "https://youtu.be/abc"
+
+
+def test_schedule_skips_iframe():
+    room = FakeRoom(
+        schedules=[FakeSchedule("https://embed/x", stream_type="iframe")]
+    )
+    assert get_schedule_stream_url(room) == ""
+
+
+# -- combined ----------------------------------------------------------
+
+
+def test_get_room_stream_url_prefers_module_over_schedule():
+    room = FakeRoom(
+        module_config=[
+            {"type": "livestream.native", "config": {"hls_url": "https://mod/x.m3u8"}}
+        ],
+        schedules=[FakeSchedule("https://sched/x.m3u8", active=True)],
+    )
+    assert get_room_stream_url(room) == "https://mod/x.m3u8"
+
+
+def test_get_room_stream_url_falls_back_to_schedule():
+    room = FakeRoom(
+        module_config=[{"type": "chat.native", "config": {}}],
+        schedules=[FakeSchedule("https://sched/x.m3u8", active=True)],
+    )
+    assert get_room_stream_url(room) == "https://sched/x.m3u8"
+
+
+# -- start-session service ---------------------------------------------
+
+
+class RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    def create_session(self, source="youtube"):
+        self.calls.append(("create_session", source))
+        return "tenant-1"
+
+    def configure(self, tenant_id, **kwargs):
+        self.calls.append(("configure", tenant_id, kwargs))
+        return None
+
+
+def test_start_stream_session_uses_susi_youtube_source():
+    client = RecordingClient()
+    tenant = start_stream_session(
+        client,
+        "https://vs-hls-push-ww-live.akamaized.net/x/master.m3u8",
+        transcription_provider="whisper_local",
+        translation_provider="nllb_local",
+    )
+    assert tenant == "tenant-1"
+    assert client.calls[0] == ("create_session", SUSI_STREAM_TYPE)
+    name, tenant_id, kwargs = client.calls[1]
+    assert name == "configure"
+    assert tenant_id == "tenant-1"
+    assert kwargs["stream_url"].endswith("master.m3u8")
+    assert kwargs["stream_type"] == SUSI_STREAM_TYPE
+    assert kwargs["transcription"] == {"provider_name": "whisper_local"}
+    assert kwargs["translation"] == {"provider_name": "nllb_local"}
+
+
+def test_start_stream_session_omits_empty_providers():
+    client = RecordingClient()
+    start_stream_session(client, "https://www.youtube.com/watch?v=abc")
+    _, _, kwargs = client.calls[1]
+    assert kwargs["transcription"] is None
+    assert kwargs["translation"] is None
+
+
+def test_start_stream_session_requires_stream_url():
+    with pytest.raises(ValueError):
+        start_stream_session(RecordingClient(), "")
+
+
+def test_room_settings_resume_path():
+    assert room_settings_resume_path(42) == "video/admin/rooms/42"

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -202,5 +202,22 @@ def test_start_stream_session_requires_stream_url():
         start_stream_session(RecordingClient(), "")
 
 
+def test_start_stream_session_rolls_back_on_configure_failure():
+    from interpretation.susi import SusiError
+
+    class FailingClient(RecordingClient):
+        def configure(self, tenant_id, **kwargs):
+            raise SusiError("configure failed")
+
+        def stop_session(self, tenant_id):
+            self.calls.append(("stop_session", tenant_id))
+
+    client = FailingClient()
+    with pytest.raises(SusiError):
+        start_stream_session(client, "https://www.youtube.com/watch?v=abc")
+    assert client.calls[0] == ("create_session", SUSI_STREAM_TYPE)
+    assert ("stop_session", "tenant-1") in client.calls
+
+
 def test_room_settings_resume_path():
     assert room_settings_resume_path(42) == "video/admin/rooms/42"

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -62,10 +62,7 @@ def test_module_youtube_id_normalized():
             {"type": "livestream.youtube", "config": {"ytid": "dQw4w9WgXcQ"}},
         ]
     )
-    assert (
-        get_module_stream_url(room)
-        == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-    )
+    assert get_module_stream_url(room) == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
 
 
 def test_module_youtube_url_passthrough():
@@ -121,9 +118,7 @@ def test_schedule_includes_youtube():
 
 
 def test_schedule_skips_iframe():
-    room = FakeRoom(
-        schedules=[FakeSchedule("https://embed/x", stream_type="iframe")]
-    )
+    room = FakeRoom(schedules=[FakeSchedule("https://embed/x", stream_type="iframe")])
     assert get_schedule_stream_url(room) == ""
 
 

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -171,6 +171,8 @@ def test_start_stream_session_uses_susi_youtube_source():
         "https://vs-hls-push-ww-live.akamaized.net/x/master.m3u8",
         transcription_provider="whisper_local",
         translation_provider="nllb_local",
+        source_language="en",
+        target_languages=["de", "fr"],
     )
     assert tenant == "tenant-1"
     assert client.calls[0] == ("create_session", SUSI_STREAM_TYPE)
@@ -180,7 +182,11 @@ def test_start_stream_session_uses_susi_youtube_source():
     assert kwargs["stream_url"].endswith("master.m3u8")
     assert kwargs["stream_type"] == SUSI_STREAM_TYPE
     assert kwargs["transcription"] == {"provider_name": "whisper_local"}
-    assert kwargs["translation"] == {"provider_name": "nllb_local"}
+    assert kwargs["translation"] == {
+        "provider_name": "nllb_local",
+        "source_lang": "en",
+        "target_lang": "de",
+    }
 
 
 def test_start_stream_session_omits_empty_providers():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,6 +9,7 @@ from interpretation.settings import (
     get_susi_client,
     is_interpretation_enabled,
     is_susi_configured,
+    is_susi_connected,
 )
 
 
@@ -59,16 +60,46 @@ def test_get_susi_client_uses_event_settings():
     assert client.auth_token == "tok"
 
 
-def test_is_susi_configured_requires_url_and_token():
+def test_is_susi_connected_requires_url_and_token():
+    assert is_susi_connected(_FakeEvent()) is False
+    assert (
+        is_susi_connected(_FakeEvent({SETTING_BASE_URL: "https://example.com"}))
+        is False
+    )
+    assert (
+        is_susi_connected(
+            _FakeEvent(
+                {
+                    SETTING_BASE_URL: "https://example.com",
+                    SETTING_AUTH_TOKEN: "tok",
+                }
+            )
+        )
+        is True
+    )
+
+
+def test_is_susi_configured_requires_enabled_and_connected():
     assert is_susi_configured(_FakeEvent()) is False
-    event_url_only = _FakeEvent({SETTING_BASE_URL: "https://example.com"})
-    assert is_susi_configured(event_url_only) is False
     assert (
         is_susi_configured(
             _FakeEvent(
                 {
                     SETTING_BASE_URL: "https://example.com",
                     SETTING_AUTH_TOKEN: "tok",
+                    SETTING_IS_ENABLED: False,
+                }
+            )
+        )
+        is False
+    )
+    assert (
+        is_susi_configured(
+            _FakeEvent(
+                {
+                    SETTING_BASE_URL: "https://example.com",
+                    SETTING_AUTH_TOKEN: "tok",
+                    SETTING_IS_ENABLED: True,
                 }
             )
         )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -79,7 +79,7 @@ def test_is_susi_connected_requires_url_and_token():
     )
 
 
-def test_is_susi_configured_requires_enabled_and_connected():
+def test_is_susi_configured_matches_connected_credentials():
     assert is_susi_configured(_FakeEvent()) is False
     assert (
         is_susi_configured(
@@ -87,19 +87,6 @@ def test_is_susi_configured_requires_enabled_and_connected():
                 {
                     SETTING_BASE_URL: "https://example.com",
                     SETTING_AUTH_TOKEN: "tok",
-                    SETTING_IS_ENABLED: False,
-                }
-            )
-        )
-        is False
-    )
-    assert (
-        is_susi_configured(
-            _FakeEvent(
-                {
-                    SETTING_BASE_URL: "https://example.com",
-                    SETTING_AUTH_TOKEN: "tok",
-                    SETTING_IS_ENABLED: True,
                 }
             )
         )


### PR DESCRIPTION
resolves #51 

# Summary
 
This PR adds the backend foundation for per-room live interpretation in interpretation plugin. Each room can independently choose an interpreter (SUSI or none for now), store its own config, and start/stop sessions without affecting other rooms.
 
This is the engine layer only. It does not include the overview/room settings UI and caption preview. Those are on `m2-room-surfaces` #52  and should merge after this PR.
 
---

## What changed
 
### Per-room data model
 
- New fields on `RoomInterpretation`:
  - `interpreter` (none / susi)
  - `room_enabled` — per-room on/off switch
  - `backend_session_id` (renamed from `susi_session_id`)
  - `backend_config` — extensible JSON for future backends
- `stream_url` renamed from `hls_url` (migration 0003)
### Backend registry
 
Pluggable interpreter dispatch:
 
| Backend | ID | Behavior |
|---|---|---|
| Noop | none | Default; cannot start sessions |
| SUSI | susi | Uses event-level JWT + `start_stream_session()` |
 
Unknown interpreter IDs safely fall back to `none`.
 
### Session lifecycle (`room_control.py`)
 
Shared helpers for views and API:
 
| Function | Purpose |
|---|---|
| `serialize_room_interpretation()` | JSON snapshot for API/UI |
| `update_room_interpretation()` | PATCH room config; auto-stops on interpreter/disable change |
| `start_room_session()` | Validate → SUSI create/configure → save tenant ID |
| `stop_room_session()` | Stop SUSI tenant; always clear local state |
| `stop_all_event_sessions()` | Stop all rooms (used on SUSI disconnect / event disable) |
 
### Stream URL resolution (`utils.py`)
 
Detects stream URL from room config:
1. Stage module (`livestream.native`, `livestream.youtube`, etc.)
2. Fallback to active/latest stream schedule (skips iframe-only)
### SUSI session orchestration (`services.py`)
 
- Creates SUSI tenant, configures transcription/translation providers
- Passes `source_lang` and first `target_lang` from room config
- Rolls back orphan tenant if configure fails after `create_session`
### Dashboard (commons)
 
- SUSI connect/disconnect/test (unchanged flow)
- Event-level "Enable live interpretation" toggle restored
- Disconnect and disabling interpretation stop all active room sessions
### Migrations
 
| Migration | Purpose |
|---|---|
| 0003 | Rename `hls_url` → `stream_url` |
| 0004 | Add `interpreter`, `room_enabled`, `backend_config`; rename session ID column (idempotent for branch-hopping DBs) |
| 0005 | Normalize legacy stopped/error status → idle; clear stale session IDs |
 
### Hardening included in this PR
 
- Idempotent start (no duplicate SUSI tenants on double-click)
- Event master switch blocks new starts
- Config size limits (`backend_config`, `target_languages`)
- Stop clears local DB even when SUSI is unreachable
- API hides `session_id` unless status is running
- Auto-stop failures during config update raise `ValueError`
- Start failure clears stale `backend_session_id`
---
 
## What is not in this PR
 
- Interpretation overview / room settings pages
- Caption preview poll endpoint
- Video admin REST API (`RoomInterpretationViewSet`)
- Production caption SSE relay (M3)
- `stream_type` mapping for modern SUSI (platform/url vs youtube)
- Per-room provider picker in commons UI (providers set via API or `RoomInterpretationForm`)
Follow-up: `m2-room-surfaces` (must be rebased onto this branch before merge).
 
---
 
## Architecture
 
```mermaid
flowchart TB
    subgraph event [Event level]
        Dashboard["Commons dashboard<br/>SUSI credentials + enable toggle"]
        Settings["event.settings<br/>JWT, base URL"]
    end
    subgraph room [Per room]
        RI["RoomInterpretation<br/>interpreter, languages, session_id"]
    end
    subgraph engine [room_control.py]
        Start["start_room_session()"]
        Stop["stop_room_session()"]
        Update["update_room_interpretation()"]
    end
    subgraph backends [Backend registry]
        SUSI["SusiBackend"]
        None["NoopBackend"]
    end
    Dashboard --> Settings
    Update --> RI
    Start --> RI
    Start --> backends
    backends --> SUSI
    SUSI -->|"HTTP"| SusiServer["SUSI Translator"]
    Settings --> SUSI
```
 
---
 
## Test plan
 
### Automated (CI)
 
```
python -m pytest tests -v
ruff check .
ruff format --check .
```
 
Expected: 68 tests pass (unit + dashboard integration with Eventyay test harness).
 
---

## Stacked PRs

| PR | Branch | Target |
|---|---|---|
| This PR | `m2-room-session-core` | `main` |
| Next | `m2-room-surfaces` | `m2-room-session-core` → retarget to `main` after merge |

Full Milestone 2 = both PRs.

