### PR TITLE
feat: add interpretation overview UI and caption preview pages

### DIFF
--- a/interpretation/dashboard_stats.py
+++ b/interpretation/dashboard_stats.py
@@ -55,11 +55,7 @@ def build_overview_context(event) -> dict:
                     "target_languages": target_languages,
                 }
             )
-        if (
-            room_on
-            and data_interpreter != RoomInterpretation.INTERPRETER_NONE
-            and not interpreter_ready
-        ):
+        if room_on and not interpreter_ready:
             room_needs_setup += 1
         if room_on and data_interpreter != RoomInterpretation.INTERPRETER_NONE:
             interpreters_in_use[data_interpreter] = (

--- a/interpretation/dashboard_stats.py
+++ b/interpretation/dashboard_stats.py
@@ -66,7 +66,7 @@ def build_overview_context(event) -> dict:
                 interpreters_in_use.get(data_interpreter, 0) + 1
             )
 
-        if room_on and data_interpreter != RoomInterpretation.INTERPRETER_NONE:
+        if status == RoomInterpretation.STATUS_RUNNING:
             snapshot_status = "running"
         elif room_on:
             snapshot_status = "ready" if interpreter_ready else "setup"

--- a/interpretation/dashboard_stats.py
+++ b/interpretation/dashboard_stats.py
@@ -1,0 +1,120 @@
+"""Aggregate interpretation status for the plugin overview landing page."""
+
+from __future__ import annotations
+
+from .backends import get_backend, list_available_interpreters
+from .models import RoomInterpretation
+from .room_control import is_room_interpretation_ready, normalize_session_status
+
+
+def build_overview_context(event) -> dict:
+    """Return template context for the interpretation overview landing page."""
+    rooms_qs = event.rooms.filter(deleted=False).order_by("name")
+    interpretations = {
+        ri.room_id: ri
+        for ri in RoomInterpretation.objects.filter(room__event=event).select_related(
+            "room"
+        )
+    }
+
+    room_total = rooms_qs.count()
+    room_enabled = 0
+    room_running = 0
+    room_needs_setup = 0
+    interpreters_in_use: dict[str, int] = {}
+    running_sessions = []
+    room_snapshots = []
+
+    for room in rooms_qs:
+        interpretation = interpretations.get(room.pk)
+        data_interpreter = RoomInterpretation.INTERPRETER_NONE
+        room_on = False
+        status = RoomInterpretation.STATUS_IDLE
+        interpreter_label = str(get_backend(RoomInterpretation.INTERPRETER_NONE).label)
+        target_languages: list[str] = []
+        interpreter_ready = False
+
+        if interpretation:
+            data_interpreter = interpretation.interpreter
+            room_on = interpretation.room_enabled
+            status = normalize_session_status(interpretation.status)
+            interpreter_label = str(get_backend(interpretation.interpreter).label)
+            target_languages = list(interpretation.target_languages or [])
+            interpreter_ready = is_room_interpretation_ready(
+                room, event, interpretation
+            )
+
+        if room_on:
+            room_enabled += 1
+        if status == RoomInterpretation.STATUS_RUNNING:
+            room_running += 1
+            running_sessions.append(
+                {
+                    "room": room,
+                    "interpreter_label": interpreter_label,
+                    "target_languages": target_languages,
+                }
+            )
+        if (
+            room_on
+            and data_interpreter != RoomInterpretation.INTERPRETER_NONE
+            and not interpreter_ready
+        ):
+            room_needs_setup += 1
+        if room_on and data_interpreter != RoomInterpretation.INTERPRETER_NONE:
+            interpreters_in_use[data_interpreter] = (
+                interpreters_in_use.get(data_interpreter, 0) + 1
+            )
+
+        if room_on and data_interpreter != RoomInterpretation.INTERPRETER_NONE:
+            snapshot_status = "running"
+        elif room_on:
+            snapshot_status = "ready" if interpreter_ready else "setup"
+        else:
+            snapshot_status = "off"
+
+        room_snapshots.append(
+            {
+                "room": room,
+                "status": snapshot_status,
+                "interpreter_label": interpreter_label
+                if data_interpreter != RoomInterpretation.INTERPRETER_NONE
+                else None,
+            }
+        )
+
+    interpreter_usage = []
+    for interpreter_id, count in sorted(interpreters_in_use.items()):
+        backend = get_backend(interpreter_id)
+        interpreter_usage.append(
+            {
+                "id": interpreter_id,
+                "label": str(backend.label),
+                "room_count": count,
+            }
+        )
+
+    backends = []
+    for backend in list_available_interpreters(event):
+        if backend["id"] == RoomInterpretation.INTERPRETER_NONE:
+            continue
+        backends.append(
+            {
+                **backend,
+                "rooms_using": interpreters_in_use.get(backend["id"], 0),
+            }
+        )
+
+    return {
+        "stats": {
+            "room_total": room_total,
+            "room_enabled": room_enabled,
+            "room_running": room_running,
+            "room_needs_setup": room_needs_setup,
+        },
+        "interpreter_usage": interpreter_usage,
+        "backends": backends,
+        "running_sessions": running_sessions,
+        "room_snapshots": room_snapshots,
+        "setup_complete": room_total > 0 and room_enabled > 0 and room_needs_setup == 0,
+    }

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -14,6 +14,10 @@ from .interpreter_credentials import (
 )
 from .settings import SETTING_IS_ENABLED, is_interpretation_enabled
 from .susi import SusiClient, SusiError
+from .susi_providers import (
+    SUSI_TRANSCRIPTION_PROVIDERS,
+    SUSI_TRANSLATION_PROVIDERS,
+)
 
 CONNECT_POST_KEY = "interpretation_connect"
 TEST_POST_KEY = "interpretation_test_connection"
@@ -22,6 +26,10 @@ INTERPRETER_ACTION_KEY = "interpretation_interpreter_action"
 INTERPRETER_ID_KEY = "interpretation_interpreter_id"
 ROOM_ID_KEY = "interpretation_room_id"
 ROOM_ACTION_KEY = "interpretation_room_action"
+PREVIEW_ACTION_KEY = "preview_action"
+PREVIEW_SAVE = "save_settings"
+PREVIEW_START = "start"
+PREVIEW_STOP = "stop"
 
 
 def verify_susi_connection(event, request) -> None:
@@ -224,3 +232,39 @@ class InterpretationSettingsForm(SettingsForm):
 
             stop_all_event_sessions(self.obj)
         return result
+
+
+class CaptionPreviewSettingsForm(forms.Form):
+    """SUSI session settings for the temporary caption preview page."""
+
+    transcription_provider = forms.ChoiceField(
+        label=_("Transcription provider"),
+        choices=[("", _("— Select —"))] + list(SUSI_TRANSCRIPTION_PROVIDERS),
+        required=True,
+    )
+    translation_provider = forms.ChoiceField(
+        label=_("Translation provider"),
+        choices=[("", _("— Select —"))] + list(SUSI_TRANSLATION_PROVIDERS),
+        required=True,
+    )
+
+    def __init__(self, *args, interpretation=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs.setdefault("class", "form-control")
+        if interpretation:
+            if interpretation.transcription_provider:
+                self.fields[
+                    "transcription_provider"
+                ].initial = interpretation.transcription_provider
+            if interpretation.translation_provider:
+                self.fields[
+                    "translation_provider"
+                ].initial = interpretation.translation_provider
+
+
+def preview_settings_payload(form: CaptionPreviewSettingsForm) -> dict:
+    return {
+        "transcription_provider": form.cleaned_data["transcription_provider"],
+        "translation_provider": form.cleaned_data["translation_provider"],
+    }

--- a/interpretation/susi_providers.py
+++ b/interpretation/susi_providers.py
@@ -1,0 +1,15 @@
+"""SUSI provider choices for organizer forms."""
+
+from django.utils.translation import gettext_lazy as _
+
+# ponytail: static list; upgrade path is SUSI /providers API when exposed.
+SUSI_TRANSCRIPTION_PROVIDERS = (
+    ("whisper_local", _("Whisper (local)")),
+    ("openai", _("OpenAI")),
+    ("deepgram", _("Deepgram")),
+)
+
+SUSI_TRANSLATION_PROVIDERS = (
+    ("nllb_local", _("NLLB (local)")),
+    ("openai", _("OpenAI")),
+)

--- a/interpretation/templates/interpretation/caption_preview.html
+++ b/interpretation/templates/interpretation/caption_preview.html
@@ -1,0 +1,137 @@
+{% extends "eventyay_common/event/base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Caption preview" %} — {{ room.name }}{% endblock %}
+{% block content %}
+    <style>{% include "interpretation/dashboard.css" %}</style>
+
+    <header class="interpretation-hero interpretation-hero--subpage">
+        <div class="interpretation-hero-text">
+            <p class="interpretation-breadcrumb">
+                <a href="{% url 'plugins:interpretation:dashboard' organizer=event.organizer.slug event=event.slug %}">
+                    {% trans "Interpretation" %}
+                </a>
+                <span aria-hidden="true"> / </span>
+                <a href="{{ rooms_url }}">{% trans "Room settings" %}</a>
+                <span aria-hidden="true"> / </span>
+                <span>{{ room.name }}</span>
+            </p>
+            <h2 class="interpretation-hero-title">{% trans "Caption preview" %}</h2>
+        </div>
+    </header>
+
+    <div class="interpretation-content interpretation-preview-page">
+        <div class="interpretation-preview-banner" role="note">
+            <strong>{% trans "Temporary" %}</strong>
+            <p>{% trans "Quick check that captions reach Eventyay. Will be removed when the Eventyay Videos caption bar PR lands." %}</p>
+        </div>
+
+        {% if not preview_supported %}
+            <p class="interpretation-preview-empty">{% trans "Caption preview only works for rooms using SUSI." %}</p>
+            <a class="interpretation-preview-back" href="{{ rooms_url }}">{% trans "Back" %}</a>
+        {% else %}
+            <form method="post" class="interpretation-preview-settings-form">
+                {% csrf_token %}
+                <div class="interpretation-preview-settings-grid">
+                    <div class="form-group">
+                        <label for="{{ preview_form.transcription_provider.id_for_label }}">
+                            {{ preview_form.transcription_provider.label }}
+                        </label>
+                        {{ preview_form.transcription_provider }}
+                    </div>
+                    <div class="form-group">
+                        <label for="{{ preview_form.translation_provider.id_for_label }}">
+                            {{ preview_form.translation_provider.label }}
+                        </label>
+                        {{ preview_form.translation_provider }}
+                    </div>
+                </div>
+
+                <div class="interpretation-preview-toolbar">
+                    <span class="interpretation-preview-session{% if is_running %} interpretation-preview-session--live{% endif %}">
+                        {% if is_running %}
+                            {% trans "Running" %}
+                        {% else %}
+                            {% trans "Stopped" %}
+                        {% endif %}
+                    </span>
+                    <button type="submit"
+                            name="{{ preview_action_key }}"
+                            value="save_settings"
+                            class="btn btn-default">
+                        {% trans "Save settings" %}
+                    </button>
+                    <button type="submit"
+                            name="{{ preview_action_key }}"
+                            value="start"
+                            class="btn btn-primary"
+                            {% if is_running %}disabled{% endif %}>
+                        {% trans "Start" %}
+                    </button>
+                    <button type="submit"
+                            name="{{ preview_action_key }}"
+                            value="stop"
+                            class="btn btn-default"
+                            {% if not is_running %}disabled{% endif %}>
+                        {% trans "Stop" %}
+                    </button>
+                    <a class="interpretation-preview-back" href="{{ rooms_url }}">{% trans "Back" %}</a>
+                </div>
+            </form>
+
+            <p id="preview-status-line" class="interpretation-preview-stream-status">
+                {% if is_running %}
+                    {% trans "Waiting for captions…" %}
+                {% endif %}
+            </p>
+
+            <div id="preview-caption-box"
+                 class="interpretation-preview-caption-box{% if not is_running %} interpretation-preview-caption-box--idle{% endif %}"
+                 aria-live="polite">
+                {% if not is_running %}
+                    <span class="interpretation-preview-caption-placeholder">{% trans "Captions appear here" %}</span>
+                {% endif %}
+            </div>
+        {% endif %}
+    </div>
+
+    {% if preview_supported and is_running %}
+        <script>
+            (function () {
+                var pollUrl = "{{ poll_url|escapejs }}";
+                var statusLine = document.getElementById("preview-status-line");
+                var captionBox = document.getElementById("preview-caption-box");
+                var lastText = "";
+
+                function poll() {
+                    fetch(pollUrl, { credentials: "same-origin", headers: { Accept: "application/json" } })
+                        .then(function (response) { return response.json(); })
+                        .then(function (data) {
+                            if (data.error) {
+                                statusLine.textContent = data.error;
+                                statusLine.classList.add("is-error");
+                                return;
+                            }
+                            if (!data.running) {
+                                statusLine.textContent = "{% trans 'Session stopped.'|escapejs %}";
+                                return;
+                            }
+                            if (data.text && data.text !== lastText) {
+                                lastText = data.text;
+                                captionBox.textContent = data.text;
+                                captionBox.classList.remove("interpretation-preview-caption-box--idle");
+                                statusLine.textContent = "{% trans 'Receiving captions.'|escapejs %}";
+                                statusLine.classList.remove("is-error");
+                            }
+                        })
+                        .catch(function () {
+                            statusLine.textContent = "{% trans 'Could not load captions.'|escapejs %}";
+                            statusLine.classList.add("is-error");
+                        });
+                }
+
+                poll();
+                window.setInterval(poll, 2000);
+            })();
+        </script>
+    {% endif %}
+{% endblock %}

--- a/interpretation/templates/interpretation/overview.html
+++ b/interpretation/templates/interpretation/overview.html
@@ -1,0 +1,206 @@
+{% extends "eventyay_common/event/base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Interpretation" %}{% endblock %}
+{% block content %}
+    <style>{% include "interpretation/dashboard.css" %}</style>
+
+    <header class="interpretation-hero interpretation-hero--welcome">
+        <div class="interpretation-hero-icon" aria-hidden="true">
+            <span class="fa fa-language"></span>
+        </div>
+        <div class="interpretation-hero-text">
+            <h2 class="interpretation-hero-title">{% trans "Interpretation" %}</h2>
+            <p class="interpretation-hero-lead">
+                {% blocktrans trimmed with event_name=event.name %}
+                    Live captions, translated audio, and language channels for {{ event_name }}.
+                {% endblocktrans %}
+            </p>
+            <div class="interpretation-hero-actions">
+                <a class="btn btn-primary"
+                   href="{% url 'plugins:interpretation:rooms' organizer=event.organizer.slug event=event.slug %}">
+                    {% trans "Room settings" %}
+                </a>
+                <a class="btn btn-default"
+                   href="{{ interpreters_url }}">
+                    {% trans "Configure interpreters" %}
+                </a>
+            </div>
+        </div>
+    </header>
+
+    <div class="interpretation-content">
+        <section class="interpretation-overview-section">
+            <h3 class="interpretation-section-title">{% trans "Event settings" %}</h3>
+            {% include "interpretation/event_enable_form.html" with form=event_settings_form event_settings_save_key=event_settings_save_key %}
+        </section>
+
+        <div class="interpretation-stat-grid">
+            <a class="interpretation-stat-card interpretation-stat-card--link"
+               href="{% url 'plugins:interpretation:rooms' organizer=event.organizer.slug event=event.slug %}">
+                <span class="interpretation-stat-label">{% trans "Rooms" %}</span>
+                <span class="interpretation-stat-value">{{ stats.room_total }}</span>
+                <span class="interpretation-stat-detail">
+                    {% blocktrans trimmed with enabled=stats.room_enabled running=stats.room_running %}
+                        {{ enabled }} enabled · {{ running }} live
+                    {% endblocktrans %}
+                </span>
+            </a>
+
+            <a class="interpretation-stat-card interpretation-stat-card--link{% if stats.room_running %} interpretation-stat-card--active{% endif %}"
+               href="{% url 'plugins:interpretation:rooms' organizer=event.organizer.slug event=event.slug %}">
+                <span class="interpretation-stat-label">{% trans "Live sessions" %}</span>
+                <span class="interpretation-stat-value">{{ stats.room_running }}</span>
+                <span class="interpretation-stat-detail">
+                    {% if stats.room_running %}
+                        {% trans "Sessions running now" %}
+                    {% else %}
+                        {% trans "Nothing live right now" %}
+                    {% endif %}
+                </span>
+            </a>
+
+            <a class="interpretation-stat-card interpretation-stat-card--link{% if stats.room_needs_setup %} interpretation-stat-card--warn{% endif %}"
+               href="{% url 'plugins:interpretation:rooms' organizer=event.organizer.slug event=event.slug %}">
+                <span class="interpretation-stat-label">{% trans "Needs attention" %}</span>
+                <span class="interpretation-stat-value">{{ stats.room_needs_setup }}</span>
+                <span class="interpretation-stat-detail">
+                    {% if stats.room_needs_setup %}
+                        {% trans "Enabled rooms need interpreter sign-in or setup" %}
+                    {% else %}
+                        {% trans "All enabled rooms look ready" %}
+                    {% endif %}
+                </span>
+            </a>
+
+            <div class="interpretation-stat-card">
+                <span class="interpretation-stat-label">{% trans "Interpreters in use" %}</span>
+                <span class="interpretation-stat-value">{{ interpreter_usage|length }}</span>
+                <span class="interpretation-stat-detail">
+                    {% if interpreter_usage %}
+                        {% for item in interpreter_usage %}
+                            {% blocktrans trimmed with label=item.label count counter=item.room_count %}
+                                {{ label }} ({{ counter }} room)
+                            {% plural %}
+                                {{ label }} ({{ counter }} rooms)
+                            {% endblocktrans %}{% if not forloop.last %}, {% endif %}
+                        {% endfor %}
+                    {% else %}
+                        {% trans "No rooms configured yet" %}
+                    {% endif %}
+                </span>
+            </div>
+        </div>
+
+        {% if running_sessions %}
+            <section class="interpretation-overview-section">
+                <h3 class="interpretation-section-title">{% trans "Live now" %}</h3>
+                <ul class="interpretation-live-list">
+                    {% for session in running_sessions %}
+                        <li class="interpretation-live-item">
+                            <div class="interpretation-live-copy">
+                                <strong>{{ session.room.name }}</strong>
+                                <span class="text-muted">
+                                    {{ session.interpreter_label }}
+                                    {% if session.target_languages %}
+                                        · {{ session.target_languages|join:", " }}
+                                    {% endif %}
+                                </span>
+                            </div>
+                            <a class="btn btn-default btn-sm"
+                               href="{% url 'plugins:interpretation:rooms' organizer=event.organizer.slug event=event.slug %}?room={{ session.room.pk }}">
+                                {% trans "Manage" %}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </section>
+        {% endif %}
+
+        <section class="interpretation-overview-section">
+            <h3 class="interpretation-section-title">{% trans "Interpreter services" %}</h3>
+            <div class="interpretation-backend-grid">
+                {% for backend in backends %}
+                    {% if backend.id != "none" %}
+                        <div class="interpretation-backend-card">
+                            <div class="interpretation-backend-head">
+                                <strong>{{ backend.label }}</strong>
+                            </div>
+                            <p class="interpretation-backend-detail text-muted">
+                                {% if backend.configured %}
+                                    {% if backend.rooms_using %}
+                                        {% blocktrans trimmed count counter=backend.rooms_using %}
+                                            Connected for this event · {{ counter }} room using it
+                                        {% plural %}
+                                            Connected for this event · {{ counter }} rooms using it
+                                        {% endblocktrans %}
+                                    {% else %}
+                                        {% trans "Connected for this event. No rooms use it yet." %}
+                                    {% endif %}
+                                {% else %}
+                                    {% trans "Not signed in for this event yet." %}
+                                    <a href="{{ interpreters_url }}">{% trans "Configure interpreters" %}</a>
+                                {% endif %}
+                            </p>
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </section>
+
+        {% if room_snapshots %}
+            <section class="interpretation-overview-section">
+                <div class="interpretation-section-head">
+                    <h3 class="interpretation-section-title">{% trans "Rooms at a glance" %}</h3>
+                    <a href="{% url 'plugins:interpretation:rooms' organizer=event.organizer.slug event=event.slug %}">
+                        {% trans "View all room settings" %} →
+                    </a>
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-hover interpretation-snapshot-table">
+                        <thead>
+                            <tr>
+                                <th>{% trans "Room" %}</th>
+                                <th>{% trans "Status" %}</th>
+                                <th>{% trans "Interpreter" %}</th>
+                                <th class="text-right">{% trans "Open" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for entry in room_snapshots %}
+                                <tr>
+                                    <td>{{ entry.room.name }}</td>
+                                    <td>
+                                        {% if entry.status == "running" %}
+                                            <span class="interpretation-badge interpretation-badge--success">{% trans "Live" %}</span>
+                                        {% elif entry.status == "ready" %}
+                                            <span class="interpretation-badge interpretation-badge--success">{% trans "Ready" %}</span>
+                                        {% elif entry.status == "setup" %}
+                                            <span class="interpretation-badge interpretation-badge--warn">{% trans "Setup" %}</span>
+                                        {% else %}
+                                            <span class="interpretation-badge">{% trans "Off" %}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if entry.interpreter_label %}
+                                            {{ entry.interpreter_label }}
+                                        {% else %}
+                                            <span class="text-muted">{% trans "None" %}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-right">
+                                        <a class="btn btn-default btn-sm"
+                                           href="{% url 'plugins:interpretation:rooms' organizer=event.organizer.slug event=event.slug %}?room={{ entry.room.pk }}">
+                                            {% trans "Configure" %}
+                                        </a>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        {% else %}
+            <p class="text-muted">{% trans "This event has no rooms yet." %}</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/interpretation/templates/interpretation/room_settings.html
+++ b/interpretation/templates/interpretation/room_settings.html
@@ -15,7 +15,7 @@
             </p>
             <h2 class="interpretation-hero-title">{% trans "Room settings" %}</h2>
             <p class="interpretation-hero-lead">
-                {% trans "Choose an interpreter per room. Sign in to interpreter services on the configure interpreters page." %}
+                {% trans "Choose an interpreter per room. Sign in on Configure interpreters. Start sessions from the caption preview page." %}
             </p>
             <div class="interpretation-hero-actions">
                 <a class="btn btn-default"
@@ -27,8 +27,6 @@
     </header>
 
     <div class="interpretation-content">
-        {% include "interpretation/event_enable_form.html" with form=event_settings_form event_settings_save_key="interpretation_event_settings_save" %}
-
         {% if not susi_connected %}
             <p class="text-muted interpretation-section-hint">
                 {% trans "SUSI is not connected for this event yet." %}
@@ -47,6 +45,7 @@
                             <th>{% trans "Interpreter" %}</th>
                             <th>{% trans "Session" %}</th>
                             <th>{% trans "Caption languages" %}</th>
+                            <th class="text-right">{% trans "Preview" %}</th>
                             <th class="text-right">{% trans "Configure" %}</th>
                         </tr>
                     </thead>
@@ -76,6 +75,12 @@
                                     {% endif %}
                                 </td>
                                 <td class="text-right">
+                                    <a class="btn btn-default btn-sm"
+                                       href="{% url 'plugins:interpretation:room.preview' organizer=event.organizer.slug event=event.slug pk=entry.room.pk %}">
+                                        {% trans "Captions" %}
+                                    </a>
+                                </td>
+                                <td class="text-right">
                                     <button type="button"
                                             class="btn btn-default btn-sm interpretation-room-toggle"
                                             data-toggle="collapse"
@@ -87,7 +92,7 @@
                                 </td>
                             </tr>
                             <tr class="interpretation-room-panel-row">
-                                <td colspan="5" class="interpretation-room-panel-cell">
+                                <td colspan="6" class="interpretation-room-panel-cell">
                                     <div id="room-panel-{{ entry.room.pk }}"
                                          class="collapse interpretation-room-panel{% if entry.expanded %} in{% endif %}">
                                         {% include "interpretation/room_configure_panel.html" with entry=entry room_id_key="interpretation_room_id" room_action_key="interpretation_room_action" interpreters_url=interpreters_url %}

--- a/interpretation/urls.py
+++ b/interpretation/urls.py
@@ -4,8 +4,10 @@ from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
 
 from .api import RoomInterpretationViewSet
 from .views import (
-    InterpretationDashboard,
+    InterpretationCaptionPreview,
+    InterpretationCaptionPreviewPoll,
     InterpretationInterpreters,
+    InterpretationOverview,
     InterpretationRoomSettings,
 )
 
@@ -20,7 +22,7 @@ _PREFIX = "common/event/<orgslug:organizer>/<slug:event>/interpretation/"
 urlpatterns = [
     path(
         _PREFIX,
-        InterpretationDashboard.as_view(),
+        InterpretationOverview.as_view(),
         name="dashboard",
     ),
     path(
@@ -32,5 +34,15 @@ urlpatterns = [
         _PREFIX + "rooms/",
         InterpretationRoomSettings.as_view(),
         name="rooms",
+    ),
+    path(
+        _PREFIX + "rooms/<int:pk>/preview/",
+        InterpretationCaptionPreview.as_view(),
+        name="room.preview",
+    ),
+    path(
+        _PREFIX + "rooms/<int:pk>/preview/poll/",
+        InterpretationCaptionPreviewPoll.as_view(),
+        name="room.preview.poll",
     ),
 ]

--- a/interpretation/utils.py
+++ b/interpretation/utils.py
@@ -166,14 +166,3 @@ def normalize_target_languages(value) -> list[str]:
             seen.add(code)
             codes.append(code)
     return codes
-
-
-def room_settings_url(organizer_slug: str, event_slug: str, room_id: int) -> str:
-    """Commons link that opens the video room editor for interpretation settings."""
-    from django.urls import reverse
-
-    base = reverse(
-        "eventyay_common:event.create_access_to_video",
-        kwargs={"organizer": organizer_slug, "event": event_slug},
-    )
-    return f"{base}?resume_path={room_settings_resume_path(room_id)}"

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -1,4 +1,5 @@
 from django.contrib import messages
+from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -7,20 +8,29 @@ from eventyay.control.permissions import EventPermissionRequiredMixin
 from eventyay.control.views.event import EventSettingsViewMixin
 
 from .backends import get_backend, list_available_interpreters
+from .dashboard_stats import build_overview_context
 from .forms import (
     CONNECT_POST_KEY,
+    EVENT_SETTINGS_SAVE_KEY,
     INTERPRETER_ACTION_KEY,
     INTERPRETER_ID_KEY,
+    PREVIEW_ACTION_KEY,
+    PREVIEW_SAVE,
+    PREVIEW_START,
+    PREVIEW_STOP,
     ROOM_ACTION_KEY,
     ROOM_ID_KEY,
+    CaptionPreviewSettingsForm,
     InterpretationSettingsForm,
     RoomConfigureForm,
     SusiInterpreterCredentialsForm,
+    preview_settings_payload,
     room_form_prefix,
     verify_susi_connection,
 )
 from .interpreter_credentials import (
     clear_interpreter_credentials,
+    get_susi_client,
     is_interpreter_configured,
     is_susi_configured,
     susi_account_label,
@@ -29,10 +39,14 @@ from .interpreter_credentials import (
 from .models import RoomInterpretation
 from .room_control import (
     clear_room_interpretation_setup,
+    get_interpretation,
+    normalize_session_status,
     serialize_room_interpretation,
+    start_room_session,
     stop_room_session,
     update_room_interpretation,
 )
+from .susi import SusiError
 
 PLUGIN_MODULE = "interpretation"
 
@@ -47,6 +61,13 @@ def _notify_stop_result(request, room, result) -> None:
     )
     if result.warning:
         messages.warning(request, result.warning)
+
+
+def _dashboard_url(event):
+    return reverse(
+        "plugins:interpretation:dashboard",
+        kwargs={"organizer": event.organizer.slug, "event": event.slug},
+    )
 
 
 def _rooms_url(event):
@@ -95,17 +116,33 @@ class InterpretationEnabledMixin:
         return super().dispatch(request, *args, **kwargs)
 
 
-class InterpretationDashboard(
+class InterpretationOverview(
     InterpretationEnabledMixin,
+    EventSettingsViewMixin,
     EventPermissionRequiredMixin,
     View,
 ):
-    """Landing: redirect organizers to room settings."""
+    """Plugin home: event-level status and quick navigation."""
 
+    template_name = "interpretation/overview.html"
     permission = "can_change_event_settings"
 
     def get(self, request, *args, **kwargs):
-        return redirect(_rooms_url(request.event))
+        event = request.event
+        context = {
+            "event": event,
+            "is_event_settings": True,
+            "event_settings_form": _event_settings_form(event),
+            "event_settings_save_key": EVENT_SETTINGS_SAVE_KEY,
+            "interpreters_url": _interpreters_url(event),
+            **build_overview_context(event),
+        }
+        return render(request, self.template_name, context)
+
+    def post(self, request, *args, **kwargs):
+        return _process_event_settings_post(
+            request, request.event, redirect_url=_dashboard_url(request.event)
+        )
 
 
 class InterpretationInterpreters(
@@ -330,8 +367,175 @@ class InterpretationRoomSettings(
             "rooms": rooms,
             "available_interpreters": list_available_interpreters(event),
             "interpreters_url": _interpreters_url(event),
-            "event_settings_form": _event_settings_form(event),
             "susi_connected": is_susi_configured(event),
             "is_event_settings": True,
             **kwargs,
         }
+
+
+def _preview_caption_text(data: dict | None) -> str:
+    if not data:
+        return ""
+    return (data.get("transcript") or data.get("translation") or "").strip()
+
+
+def _preview_session(room, event):
+    interpretation = get_interpretation(room)
+    if interpretation is None:
+        return None, False
+    is_running = (
+        interpretation.interpreter == RoomInterpretation.INTERPRETER_SUSI
+        and normalize_session_status(interpretation.status)
+        == RoomInterpretation.STATUS_RUNNING
+        and bool(interpretation.backend_session_id)
+    )
+    return interpretation, is_running
+
+
+def _preview_settings_form(room, event, data=None):
+    interpretation = get_interpretation(room)
+    return CaptionPreviewSettingsForm(
+        data=data,
+        interpretation=interpretation,
+    )
+
+
+def _apply_preview_settings(request, room, event):
+    form = _preview_settings_form(room, event, data=request.POST)
+    if not form.is_valid():
+        return None, form
+    try:
+        update_room_interpretation(room, event, preview_settings_payload(form))
+    except ValueError as exc:
+        return None, str(exc)
+    return form, None
+
+
+class InterpretationCaptionPreview(
+    InterpretationEnabledMixin,
+    EventSettingsViewMixin,
+    EventPermissionRequiredMixin,
+    View,
+):
+    """Temporary organizer page to verify SUSI captions reach Eventyay."""
+
+    template_name = "interpretation/caption_preview.html"
+    permission = "can_change_event_settings"
+
+    def _room(self, event, pk):
+        return get_object_or_404(event.rooms.filter(deleted=False), pk=pk)
+
+    def _preview_url(self, room):
+        return reverse(
+            "plugins:interpretation:room.preview",
+            kwargs={
+                "organizer": self.request.event.organizer.slug,
+                "event": self.request.event.slug,
+                "pk": room.pk,
+            },
+        )
+
+    def get(self, request, pk, *args, **kwargs):
+        event = request.event
+        room = self._room(event, pk)
+        return render(request, self.template_name, self._context(event, room))
+
+    def post(self, request, pk, *args, **kwargs):
+        event = request.event
+        room = self._room(event, pk)
+        action = request.POST.get(PREVIEW_ACTION_KEY)
+        redirect_url = self._preview_url(room)
+
+        if action == PREVIEW_SAVE:
+            _settings, error = _apply_preview_settings(request, room, event)
+            if error is not None:
+                if isinstance(error, str):
+                    messages.error(request, error)
+                else:
+                    messages.error(
+                        request,
+                        _("Could not save preview settings. Check the fields below."),
+                    )
+            else:
+                messages.success(request, _("Saved preview settings."))
+        elif action == PREVIEW_START:
+            _settings, error = _apply_preview_settings(request, room, event)
+            if error is not None:
+                if isinstance(error, str):
+                    messages.error(request, error)
+                else:
+                    messages.error(
+                        request,
+                        _("Could not start the session. Check the settings below."),
+                    )
+                return redirect(redirect_url)
+            result = start_room_session(room, event)
+            if result.ok:
+                messages.success(
+                    request,
+                    _("Started interpretation session for %(room)s.")
+                    % {"room": room.name},
+                )
+            else:
+                messages.error(request, result.error)
+        elif action == PREVIEW_STOP:
+            result = stop_room_session(room, event)
+            _notify_stop_result(request, room, result)
+        else:
+            messages.error(request, _("Unknown preview action."))
+
+        return redirect(redirect_url)
+
+    def _context(self, event, room):
+        interpretation, is_running = _preview_session(room, event)
+        data = serialize_room_interpretation(room, event, interpretation)
+        return {
+            "event": event,
+            "room": room,
+            "data": data,
+            "preview_form": _preview_settings_form(room, event),
+            "preview_action_key": PREVIEW_ACTION_KEY,
+            "is_running": is_running,
+            "preview_supported": data.get("interpreter")
+            == RoomInterpretation.INTERPRETER_SUSI,
+            "poll_url": reverse(
+                "plugins:interpretation:room.preview.poll",
+                kwargs={
+                    "organizer": event.organizer.slug,
+                    "event": event.slug,
+                    "pk": room.pk,
+                },
+            ),
+            "rooms_url": _rooms_url(event),
+            "interpreters_url": _interpreters_url(event),
+            "susi_connected": is_susi_configured(event),
+            "is_event_settings": True,
+        }
+
+
+class InterpretationCaptionPreviewPoll(
+    InterpretationEnabledMixin,
+    EventPermissionRequiredMixin,
+    View,
+):
+    """Temporary JSON poll endpoint for the caption preview page."""
+
+    permission = "can_change_event_settings"
+    http_method_names = ["get"]
+
+    def get(self, request, pk, *args, **kwargs):
+        room = get_object_or_404(
+            request.event.rooms.filter(deleted=False),
+            pk=pk,
+        )
+        interpretation, is_running = _preview_session(room, request.event)
+        if interpretation is None or not is_running:
+            return JsonResponse({"running": False, "text": "", "error": ""})
+
+        client = get_susi_client(request.event)
+        try:
+            result = client.latest_transcript(interpretation.backend_session_id)
+            text = _preview_caption_text(result.data if result.ok else None)
+            return JsonResponse({"running": True, "text": text, "error": ""})
+        except SusiError as exc:
+            return JsonResponse({"running": True, "text": "", "error": str(exc)})

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -535,7 +535,9 @@ class InterpretationCaptionPreviewPoll(
         client = get_susi_client(request.event)
         try:
             result = client.latest_transcript(interpretation.backend_session_id)
-            text = _preview_caption_text(result.data if result.ok else None)
+            if not result.ok:
+                return JsonResponse({"running": True, "text": "", "error": str(result.data)})
+            text = _preview_caption_text(result.data)
             return JsonResponse({"running": True, "text": text, "error": ""})
         except SusiError as exc:
             return JsonResponse({"running": True, "text": "", "error": str(exc)})

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -1,0 +1,82 @@
+"""Authorization tests for interpretation commons views."""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+@pytest.fixture
+def room(event):
+    from eventyay.base.models import Room
+
+    return Room.objects.create(event=event, name="Main Stage")
+
+
+@pytest.fixture
+def restricted_client(client, db, organizer):
+    from eventyay.base.models import Team
+
+    user = User.objects.create_user(
+        email="restricted@example.com",
+        password="testpass123",
+        fullname="Restricted",
+        locale="en",
+    )
+    team = Team.objects.create(
+        organizer=organizer,
+        name="View Only",
+        all_events=True,
+        can_change_event_settings=False,
+    )
+    team.members.add(user)
+    client.force_login(user)
+    return client
+
+
+def test_anonymous_user_redirected_from_dashboard(client, dashboard_url):
+    response = client.get(dashboard_url)
+
+    assert response.status_code == 302
+    assert "login" in response.url.lower() or "account" in response.url.lower()
+
+
+def test_restricted_user_denied_dashboard(restricted_client, dashboard_url):
+    response = restricted_client.get(dashboard_url)
+
+    assert response.status_code in {403, 302}
+
+
+def test_cross_event_room_action_returns_404(
+    organizer_client, event, connected_event, rooms_url
+):
+    from eventyay.base.models import Event, Room
+
+    other = Event.objects.create(
+        organizer=event.organizer,
+        name="Other Event",
+        slug="otherevent",
+        date_from=event.date_from,
+        date_to=event.date_to,
+        currency="USD",
+        locale="en",
+        is_public=True,
+        live=True,
+        email="other@example.com",
+    )
+    other.plugins = "interpretation"
+    other.save(update_fields=["plugins"])
+    other_room = Room.objects.create(event=other, name="Other Room")
+
+    response = organizer_client.post(
+        rooms_url,
+        {
+            "interpretation_room_id": str(other_room.pk),
+            "interpretation_room_action": "save",
+            "room-999-interpreter": "susi",
+        },
+    )
+
+    assert response.status_code == 404

--- a/tests/test_caption_preview.py
+++ b/tests/test_caption_preview.py
@@ -1,0 +1,185 @@
+"""Tests for the temporary caption preview page."""
+
+import pytest
+from django.urls import reverse
+
+from interpretation.models import RoomInterpretation
+from interpretation.room_control import SessionResult
+from interpretation.susi import SusiResult
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def room(event):
+    from eventyay.base.models import Room
+
+    return Room.objects.create(event=event, name="Main Stage")
+
+
+def preview_url(event, room):
+    return reverse(
+        "plugins:interpretation:room.preview",
+        kwargs={
+            "organizer": event.organizer.slug,
+            "event": event.slug,
+            "pk": room.pk,
+        },
+    )
+
+
+def preview_poll_url(event, room):
+    return reverse(
+        "plugins:interpretation:room.preview.poll",
+        kwargs={
+            "organizer": event.organizer.slug,
+            "event": event.slug,
+            "pk": room.pk,
+        },
+    )
+
+
+def test_preview_page_is_simple(organizer_client, connected_event, room):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+    )
+
+    response = organizer_client.get(preview_url(connected_event, room))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Temporary" in content
+    assert "Start" in content
+    assert "Stop" in content
+    assert "interpretation-preview-page" in content
+    assert "Transcription provider" in content
+    assert "Translation provider" in content
+    assert "Caption language" not in content
+    assert "Session ID" not in content
+
+
+def test_preview_poll_requires_running_session(organizer_client, connected_event, room):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+        status=RoomInterpretation.STATUS_IDLE,
+    )
+
+    response = organizer_client.get(preview_poll_url(connected_event, room))
+
+    assert response.status_code == 200
+    assert response.json() == {"running": False, "text": "", "error": ""}
+
+
+def test_preview_treats_legacy_stopped_status_as_not_running(
+    organizer_client, connected_event, room
+):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+        status=RoomInterpretation.STATUS_STOPPED,
+        backend_session_id="stale-tenant",
+    )
+
+    response = organizer_client.get(preview_poll_url(connected_event, room))
+
+    assert response.status_code == 200
+    assert response.json() == {"running": False, "text": "", "error": ""}
+
+
+def test_preview_poll_returns_transcript(
+    organizer_client, connected_event, room, monkeypatch
+):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+        status=RoomInterpretation.STATUS_RUNNING,
+        backend_session_id="tenant-1",
+    )
+
+    class FakeClient:
+        def latest_transcript(self, tenant_id):
+            assert tenant_id == "tenant-1"
+            return SusiResult(
+                ok=True,
+                status_code=200,
+                data={"transcript": "hello world"},
+            )
+
+    monkeypatch.setattr(
+        "interpretation.views.get_susi_client",
+        lambda event: FakeClient(),
+    )
+
+    response = organizer_client.get(preview_poll_url(connected_event, room))
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "running": True,
+        "text": "hello world",
+        "error": "",
+    }
+
+
+def _preview_settings_post():
+    return {
+        "preview_action": "start",
+        "transcription_provider": "whisper_local",
+        "translation_provider": "nllb_local",
+    }
+
+
+def test_preview_save_settings(organizer_client, connected_event, room):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+    )
+
+    response = organizer_client.post(
+        preview_url(connected_event, room),
+        {
+            "preview_action": "save_settings",
+            "transcription_provider": "whisper_local",
+            "translation_provider": "nllb_local",
+        },
+    )
+
+    assert response.status_code == 302
+    interpretation = RoomInterpretation.objects.get(room=room)
+    assert interpretation.transcription_provider == "whisper_local"
+    assert interpretation.translation_provider == "nllb_local"
+
+
+def test_preview_start_action(organizer_client, connected_event, room, monkeypatch):
+    interpretation = RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+    )
+
+    def fake_start(room_arg, event, *, stream_url_override=""):
+        return SessionResult(ok=True, interpretation=interpretation)
+
+    monkeypatch.setattr("interpretation.views.start_room_session", fake_start)
+
+    response = organizer_client.post(
+        preview_url(connected_event, room),
+        _preview_settings_post(),
+    )
+
+    assert response.status_code == 302
+    interpretation.refresh_from_db()
+    assert interpretation.transcription_provider == "whisper_local"
+
+
+def test_preview_caption_text_uses_transcript():
+    from interpretation.views import _preview_caption_text
+
+    assert _preview_caption_text({"transcript": "hello"}) == "hello"
+    assert _preview_caption_text({"translation": "hallo"}) == "hallo"

--- a/tests/test_dashboard_stats.py
+++ b/tests/test_dashboard_stats.py
@@ -1,0 +1,38 @@
+"""Tests for dashboard overview stats aggregation."""
+
+import pytest
+
+from interpretation.dashboard_stats import build_overview_context
+from interpretation.models import RoomInterpretation
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def room(event):
+    from eventyay.base.models import Room
+
+    return Room.objects.create(event=event, name="Workshop")
+
+
+def test_build_overview_context_counts(event, room, connected_room):
+    context = build_overview_context(event)
+
+    assert context["stats"]["room_total"] == 1
+    assert context["stats"]["room_enabled"] == 1
+    assert context["stats"]["room_running"] == 0
+    assert context["stats"]["room_needs_setup"] == 0
+    assert len(context["interpreter_usage"]) == 1
+    assert context["interpreter_usage"][0]["id"] == RoomInterpretation.INTERPRETER_SUSI
+
+
+def test_build_overview_context_flags_unconfigured_susi(event, room):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+    )
+
+    context = build_overview_context(event)
+
+    assert context["stats"]["room_needs_setup"] == 1

--- a/tests/test_dashboard_stats.py
+++ b/tests/test_dashboard_stats.py
@@ -55,3 +55,35 @@ def test_build_overview_context_marks_event_susi_connected(
     assert context["stats"]["room_needs_setup"] == 0
     assert context["backends"][0]["configured"] is True
     assert context["backends"][0]["rooms_using"] == 1
+
+
+def test_build_overview_snapshot_idle_room_is_not_running(
+    connected_event,
+    room,
+):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+        status=RoomInterpretation.STATUS_IDLE,
+    )
+
+    context = build_overview_context(connected_event)
+
+    assert context["stats"]["room_running"] == 0
+    assert context["room_snapshots"][0]["status"] == "ready"
+
+
+def test_build_overview_snapshot_running_room(connected_event, room):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+        status=RoomInterpretation.STATUS_RUNNING,
+        backend_session_id="tenant-1",
+    )
+
+    context = build_overview_context(connected_event)
+
+    assert context["stats"]["room_running"] == 1
+    assert context["room_snapshots"][0]["status"] == "running"

--- a/tests/test_dashboard_stats.py
+++ b/tests/test_dashboard_stats.py
@@ -36,3 +36,20 @@ def test_build_overview_context_flags_unconfigured_susi(event, room):
     context = build_overview_context(event)
 
     assert context["stats"]["room_needs_setup"] == 1
+    assert context["backends"][0]["configured"] is False
+
+
+def test_build_overview_context_marks_event_susi_connected(
+    event, room, connected_event,
+):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+    )
+
+    context = build_overview_context(connected_event)
+
+    assert context["stats"]["room_needs_setup"] == 0
+    assert context["backends"][0]["configured"] is True
+    assert context["backends"][0]["rooms_using"] == 1

--- a/tests/test_dashboard_stats.py
+++ b/tests/test_dashboard_stats.py
@@ -40,7 +40,9 @@ def test_build_overview_context_flags_unconfigured_susi(event, room):
 
 
 def test_build_overview_context_marks_event_susi_connected(
-    event, room, connected_event,
+    event,
+    room,
+    connected_event,
 ):
     RoomInterpretation.objects.create(
         room=room,

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -88,7 +88,9 @@ def test_room_settings_renders_table(organizer_client, rooms_url, room):
     assert "Configure" in content
 
 
-def test_overview_links_to_interpreters(organizer_client, dashboard_url, interpreters_url):
+def test_overview_links_to_interpreters(
+    organizer_client, dashboard_url, interpreters_url,
+):
     response = organizer_client.get(dashboard_url)
 
     assert response.status_code == 200

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -1,0 +1,103 @@
+"""Tests for the interpretation overview landing page."""
+
+import pytest
+
+from interpretation.models import RoomInterpretation
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def room(event):
+    from eventyay.base.models import Room
+
+    return Room.objects.create(event=event, name="Main Stage")
+
+
+def test_overview_renders(organizer_client, dashboard_url):
+    response = organizer_client.get(dashboard_url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Room settings" in content
+    assert "Enable live interpretation for this event" in content
+
+
+def test_overview_disable_stops_sessions(
+    monkeypatch, organizer_client, dashboard_url, connected_event, room
+):
+    from interpretation.settings import SETTING_IS_ENABLED
+
+    connected_event.settings.set(SETTING_IS_ENABLED, True)
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+        status=RoomInterpretation.STATUS_RUNNING,
+        backend_session_id="tenant-1",
+    )
+    stopped = []
+
+    def fake_stop_all(event):
+        stopped.append(event)
+
+    monkeypatch.setattr(
+        "interpretation.room_control.stop_all_event_sessions",
+        fake_stop_all,
+    )
+
+    response = organizer_client.post(
+        dashboard_url,
+        {
+            "interpretation_event_settings_save": "1",
+            "interpretation-interpretation_is_enabled": "",
+        },
+    )
+
+    assert response.status_code == 302
+    assert stopped == [connected_event]
+    connected_event.settings.flush()
+    assert connected_event.settings.get(SETTING_IS_ENABLED, as_type=bool) is False
+
+
+def test_overview_shows_room_stats(organizer_client, dashboard_url, room):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+        status=RoomInterpretation.STATUS_RUNNING,
+        target_languages=["de", "fr"],
+    )
+
+    response = organizer_client.get(dashboard_url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Main Stage" in content
+    assert "Live now" in content
+    assert "1" in content
+
+
+def test_room_settings_renders_table(organizer_client, rooms_url, room):
+    response = organizer_client.get(rooms_url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Room settings" in content
+    assert "Main Stage" in content
+    assert "Configure" in content
+
+
+def test_overview_links_to_interpreters(organizer_client, dashboard_url, interpreters_url):
+    response = organizer_client.get(dashboard_url)
+
+    assert response.status_code == 200
+    assert interpreters_url in response.content.decode()
+    assert "Configure interpreters" in response.content.decode()
+
+
+def test_overview_links_to_room_settings(organizer_client, dashboard_url, rooms_url):
+    response = organizer_client.get(dashboard_url)
+
+    assert response.status_code == 200
+    assert rooms_url in response.content.decode()

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -89,7 +89,9 @@ def test_room_settings_renders_table(organizer_client, rooms_url, room):
 
 
 def test_overview_links_to_interpreters(
-    organizer_client, dashboard_url, interpreters_url,
+    organizer_client,
+    dashboard_url,
+    interpreters_url,
 ):
     response = organizer_client.get(dashboard_url)
 

--- a/tests/test_preview_settings.py
+++ b/tests/test_preview_settings.py
@@ -1,0 +1,30 @@
+"""Tests for caption preview settings form and helpers."""
+
+from interpretation.forms import (
+    CaptionPreviewSettingsForm,
+    preview_settings_payload,
+)
+
+
+def test_preview_settings_payload_maps_providers():
+    form = CaptionPreviewSettingsForm(
+        data={
+            "transcription_provider": "whisper_local",
+            "translation_provider": "nllb_local",
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert preview_settings_payload(form) == {
+        "transcription_provider": "whisper_local",
+        "translation_provider": "nllb_local",
+    }
+
+
+def test_preview_settings_form_requires_providers():
+    form = CaptionPreviewSettingsForm(
+        data={
+            "transcription_provider": "",
+            "translation_provider": "",
+        }
+    )
+    assert not form.is_valid()


### PR DESCRIPTION
resolves #53, #18 

This PR is stacked on #54. needs rebase after 54 merges. 
 
## Summary
 
Added an Interpretation overview landing page and a temporary caption preview tool for organizers. Built on #54 event-level SUSI sign-in, no new credential model, only UX and visibility.
 
---
 
## Problem
 
PR2 sent `/interpretation/` straight to room settings. Organizers lacked:
 
- A quick view of event-wide interpretation status
- A simple way to check captions work before the real caption bar shipped
PR3 adds a home page for interpretation and a dev preview page per room.
 
---
 
## What changed
 
### Overview landing page (new default home)
 
`/interpretation/` is now a dashboard, not a redirect.
 
Shows:
 
- Event enable/disable toggle (moved here from room settings)
- Stat cards: rooms, live sessions, needs attention, interpreters in use
- **Live now**  running rooms with languages
- **Interpreter services**  event-level connected / not signed in, link to Configure interpreters
- **Rooms at a glance**  table with status (Off / Setup / Ready / Live)
Quick links: Room settings, Configure interpreters.
 
Stats use PR2's event-level auth: a room "needs attention" when it's enabled with an interpreter but the event isn't signed in or isn't ready to start.
 
### Room settings (small UX updates)
 
`/interpretation/rooms/`
 
- Captions column → links to preview page per room
- Banner when SUSI not connected for event (link to Configure interpreters)
- Event enable toggle removed (lives on overview now)
- Copy updated: sign in on Configure interpreters; start sessions from preview
Room configure panel unchanged in spirit: interpreter dropdown, enable, save/stop/clear.
 
### Caption preview (temporary)
 
`/interpretation/rooms/{id}/preview/`
 
Organizer-only page to verify SUSI captions reach Eventyay before the Videos caption bar PR lands.
 
Can:
 
- Pick transcription + translation provider
- Save settings, start/stop session (reuses PR2 session logic + event creds)
- Poll for latest caption text every 2s while running
Poll endpoint: `GET …/preview/poll/` → JSON `{ running, text, error }`
 
Uses `get_susi_client(event)` — same event token as PR2, not per-room secrets.
 
Marked **Temporary** in the UI; intended to be removed when the caption bar ships.
 
### New helpers
 
- `dashboard_stats.py` — aggregates room/session stats for overview
- `susi_providers.py` — static provider choices for preview form (Whisper, NLLB, etc.)
---
 
## Routes (full stack after PR3)
 
| URL | Purpose |
|---|---|
| `/interpretation/` | Overview (new home) |
| `/interpretation/interpreters/` | Event-level SUSI sign-in (PR2) |
| `/interpretation/rooms/` | Per-room interpreter selection (PR2 + preview link) |
| `/interpretation/rooms/{id}/preview/` | Temporary caption preview |
| `/interpretation/rooms/{id}/preview/poll/` | JSON poll for preview page |
 
---
 
## Architecture notes
 
- No credential changes — overview/preview read event settings from PR2
- Permissions — all new pages require `can_change_event_settings`
- Cross-event safety — preview/poll only load rooms on `request.event` (404 for wrong event)
- Snapshot status fix — "Rooms at a glance" shows Live only when a session is actually running, not merely when SUSI is selected
---
 
## Test plan
 
- [ ] Overview loads with stats, event toggle, links to rooms + interpreters
- [ ] Disable interpretation on overview → stops active sessions
- [ ] Room enabled + SUSI, event not signed in → "Needs attention" > 0, backend card shows Configure link
- [ ] Idle enabled room → snapshot Ready, not Live; stat card shows 0 live
- [ ] Running session → "Live now" section + snapshot Live
- [ ] Room settings → Captions opens preview for that room
- [ ] Preview: save providers, start/stop, captions appear while polling
- [ ] Preview poll with no running session → `{ running: false }`
- [ ] Restricted user / anonymous → denied from overview (authz tests)
- [ ] Cross-event room ID on room POST → 404
- [ ] `pytest tests -v` — full suite (~102 tests)
---

## Preview feat:

https://github.com/user-attachments/assets/acd08401-364f-4466-b42a-018e3ba50904


 
## Out of scope
 
- Public attendee caption SSE / caption bar (future Videos PR)
 