### PR TITLE
fix: update VoxBento API URL to use /api/events

### DIFF
--- a/interpretation/backends/voxbento.py
+++ b/interpretation/backends/voxbento.py
@@ -55,6 +55,7 @@ class VoxbentoBackend(InterpreterBackend):
                 "language_code": lang,
                 "language": lang.upper(),
                 "room_id": interpretation.room_id,
+                "room_name": str(interpretation.room.name),
             }
             try:
                 response = requests.post(

--- a/interpretation/backends/voxbento.py
+++ b/interpretation/backends/voxbento.py
@@ -39,7 +39,7 @@ class VoxbentoBackend(InterpreterBackend):
         if not base_url or not api_key:
             return
 
-        url = f"{base_url.rstrip('/')}/api/v1/events/{event.slug}/booths"
+        url = f"{base_url.rstrip('/')}/api/events/{event.slug}/booths"
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",

--- a/interpretation/backends/voxbento.py
+++ b/interpretation/backends/voxbento.py
@@ -53,7 +53,8 @@ class VoxbentoBackend(InterpreterBackend):
         for lang in interpretation.target_languages:
             payload = {
                 "language_code": lang,
-                "room_id": interpretation.room.pk,
+                "language": lang.upper(),
+                "room_id": interpretation.room_id,
             }
             try:
                 response = requests.post(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct VoxBento events booths API URL to align with the current /api/events path instead of the deprecated /api/v1/events path.