### PR TITLE
Feat/caption preview

### DIFF
--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -365,7 +365,9 @@ class CaptionPreviewSettingsForm(forms.Form):
         for field in self.fields.values():
             field.widget.attrs.setdefault("class", "form-control")
         if interpretation:
-            self.fields["transcription_provider"].initial = resolve_transcription_provider(
+            self.fields[
+                "transcription_provider"
+            ].initial = resolve_transcription_provider(
                 interpretation.transcription_provider
             )
             self.fields["translation_provider"].initial = resolve_translation_provider(

--- a/interpretation/forms.py
+++ b/interpretation/forms.py
@@ -15,8 +15,12 @@ from .interpreter_credentials import (
 from .settings import SETTING_IS_ENABLED, is_interpretation_enabled
 from .susi import SusiClient, SusiError
 from .susi_providers import (
+    DEFAULT_SUSI_TRANSCRIPTION_PROVIDER,
+    DEFAULT_SUSI_TRANSLATION_PROVIDER,
     SUSI_TRANSCRIPTION_PROVIDERS,
     SUSI_TRANSLATION_PROVIDERS,
+    resolve_transcription_provider,
+    resolve_translation_provider,
 )
 
 CONNECT_POST_KEY = "interpretation_connect"
@@ -361,14 +365,19 @@ class CaptionPreviewSettingsForm(forms.Form):
         for field in self.fields.values():
             field.widget.attrs.setdefault("class", "form-control")
         if interpretation:
-            if interpretation.transcription_provider:
-                self.fields[
-                    "transcription_provider"
-                ].initial = interpretation.transcription_provider
-            if interpretation.translation_provider:
-                self.fields[
-                    "translation_provider"
-                ].initial = interpretation.translation_provider
+            self.fields["transcription_provider"].initial = resolve_transcription_provider(
+                interpretation.transcription_provider
+            )
+            self.fields["translation_provider"].initial = resolve_translation_provider(
+                interpretation.translation_provider
+            )
+        else:
+            self.fields[
+                "transcription_provider"
+            ].initial = DEFAULT_SUSI_TRANSCRIPTION_PROVIDER
+            self.fields[
+                "translation_provider"
+            ].initial = DEFAULT_SUSI_TRANSLATION_PROVIDER
 
 
 def preview_settings_payload(form: CaptionPreviewSettingsForm) -> dict:

--- a/interpretation/preview_stream.py
+++ b/interpretation/preview_stream.py
@@ -1,0 +1,85 @@
+"""SSE proxy from SUSI to the organizer caption preview."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import queue
+import threading
+
+from .susi import SusiError
+
+# ponytail: padding forces first TCP flush through buffered ASGI/proxies.
+_FLUSH_PAD = b": " + (b"-" * 8192) + b"\n\n"
+_HEARTBEAT = b": heartbeat\n\n"
+_CONNECTED = b'data: {"status":"connected"}\n\n'
+_HEARTBEAT_SECS = 25.0
+
+
+def _relay_upstream(client, tenant_id: str, put) -> None:
+    try:
+        for chunk in client.iter_caption_stream(tenant_id):
+            if chunk:
+                put(chunk)
+    except SusiError as exc:
+        payload = json.dumps({"status": "error", "message": str(exc)})
+        put(f"data: {payload}\n\n".encode())
+
+
+def stream_susi_captions_sync(client, tenant_id: str):
+    """Yield SUSI SSE bytes; flush open comment first, then relay in a thread."""
+    yield b": stream-open\n\n"
+    yield _FLUSH_PAD
+    yield _CONNECTED
+
+    out: queue.Queue = queue.Queue()
+    done = object()
+
+    def put(item) -> None:
+        out.put(item)
+
+    def upstream() -> None:
+        _relay_upstream(client, tenant_id, put)
+        out.put(done)
+
+    threading.Thread(target=upstream, daemon=True).start()
+
+    while True:
+        try:
+            chunk = out.get(timeout=_HEARTBEAT_SECS)
+        except queue.Empty:
+            yield _HEARTBEAT
+            continue
+        if chunk is done:
+            break
+        yield chunk
+
+
+async def stream_susi_captions_async(client, tenant_id: str):
+    """Async SSE relay for Daphne — flush headers before blocking SUSI read."""
+    yield b": stream-open\n\n"
+    yield _FLUSH_PAD
+    yield _CONNECTED
+
+    out: asyncio.Queue = asyncio.Queue()
+    done = object()
+    loop = asyncio.get_running_loop()
+
+    def put(item) -> None:
+        loop.call_soon_threadsafe(out.put_nowait, item)
+
+    def upstream() -> None:
+        _relay_upstream(client, tenant_id, put)
+        put(done)
+
+    threading.Thread(target=upstream, daemon=True).start()
+
+    while True:
+        try:
+            chunk = await asyncio.wait_for(out.get(), timeout=_HEARTBEAT_SECS)
+        except TimeoutError:
+            yield _HEARTBEAT
+            continue
+        if chunk is done:
+            break
+        yield chunk

--- a/interpretation/preview_stream.py
+++ b/interpretation/preview_stream.py
@@ -16,9 +16,20 @@ _CONNECTED = b'data: {"status":"connected"}\n\n'
 _HEARTBEAT_SECS = 25.0
 
 
-def _relay_upstream(client, tenant_id: str, put) -> None:
+def _relay_upstream(
+    client,
+    tenant_id: str,
+    put,
+    *,
+    target_lang: str = "",
+    last_chunk_id: str = "0",
+) -> None:
     try:
-        for chunk in client.iter_caption_stream(tenant_id):
+        for chunk in client.iter_caption_stream(
+            tenant_id,
+            target_lang=target_lang,
+            last_chunk_id=last_chunk_id,
+        ):
             if chunk:
                 put(chunk)
     except SusiError as exc:
@@ -26,7 +37,13 @@ def _relay_upstream(client, tenant_id: str, put) -> None:
         put(f"data: {payload}\n\n".encode())
 
 
-def stream_susi_captions_sync(client, tenant_id: str):
+def stream_susi_captions_sync(
+    client,
+    tenant_id: str,
+    *,
+    target_lang: str = "",
+    last_chunk_id: str = "0",
+):
     """Yield SUSI SSE bytes; flush open comment first, then relay in a thread."""
     yield b": stream-open\n\n"
     yield _FLUSH_PAD
@@ -39,7 +56,13 @@ def stream_susi_captions_sync(client, tenant_id: str):
         out.put(item)
 
     def upstream() -> None:
-        _relay_upstream(client, tenant_id, put)
+        _relay_upstream(
+            client,
+            tenant_id,
+            put,
+            target_lang=target_lang,
+            last_chunk_id=last_chunk_id,
+        )
         out.put(done)
 
     threading.Thread(target=upstream, daemon=True).start()
@@ -55,7 +78,13 @@ def stream_susi_captions_sync(client, tenant_id: str):
         yield chunk
 
 
-async def stream_susi_captions_async(client, tenant_id: str):
+async def stream_susi_captions_async(
+    client,
+    tenant_id: str,
+    *,
+    target_lang: str = "",
+    last_chunk_id: str = "0",
+):
     """Async SSE relay for Daphne — flush headers before blocking SUSI read."""
     yield b": stream-open\n\n"
     yield _FLUSH_PAD
@@ -69,7 +98,13 @@ async def stream_susi_captions_async(client, tenant_id: str):
         loop.call_soon_threadsafe(out.put_nowait, item)
 
     def upstream() -> None:
-        _relay_upstream(client, tenant_id, put)
+        _relay_upstream(
+            client,
+            tenant_id,
+            put,
+            target_lang=target_lang,
+            last_chunk_id=last_chunk_id,
+        )
         put(done)
 
     threading.Thread(target=upstream, daemon=True).start()

--- a/interpretation/services.py
+++ b/interpretation/services.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from .susi import SusiError
-from .utils import SUSI_STREAM_TYPE
+from .susi_providers import (
+    resolve_transcription_provider,
+    resolve_translation_provider,
+)
+from .utils import SUSI_SESSION_SOURCE, SUSI_STREAM_TYPE
 
 
 def _provider_config(provider_name: str):
-    return {"provider_name": provider_name} if provider_name else None
+    resolved = resolve_transcription_provider(provider_name)
+    return {"provider_name": resolved}
 
 
 def _translation_config(
@@ -16,9 +21,8 @@ def _translation_config(
     source_language: str = "",
     target_languages: list[str] | None = None,
 ):
-    if not provider_name:
-        return None
-    cfg = {"provider_name": provider_name}
+    resolved = resolve_translation_provider(provider_name)
+    cfg = {"provider_name": resolved}
     source = (source_language or "").strip()
     if source:
         cfg["source_lang"] = source
@@ -41,16 +45,14 @@ def start_stream_session(
 ) -> str:
     """Create a SUSI session and configure it to ingest ``stream_url``.
 
-    All Eventyay stream URLs are sent through SUSI's ``youtube`` source
-    (``YouTubeSource``), which handles YouTube, Twitch, Vimeo, and HLS via
-    yt-dlp / ffmpeg.
+    Eventyay stream URLs use SUSI ``platform`` ingest (YouTube/Twitch/Vimeo/HLS).
 
     Returns the SUSI tenant/session id. Raises ``SusiError`` on failure.
     """
     if not stream_url:
         raise ValueError("stream_url is required to start a session")
 
-    tenant_id = client.create_session(source=SUSI_STREAM_TYPE)
+    tenant_id = client.create_session(source=SUSI_SESSION_SOURCE)
     try:
         client.configure(
             tenant_id,

--- a/interpretation/susi.py
+++ b/interpretation/susi.py
@@ -196,28 +196,25 @@ class SusiClient:
         """Stop the grabber and release resources for a tenant."""
         return self._request("POST", f"/stop_event/{tenant_id}")
 
-    def _stream_headers(self) -> dict:
-        headers = {"Accept": "text/event-stream", "Cache-Control": "no-cache"}
-        if self.auth_token:
-            headers["Authorization"] = f"Bearer {self.auth_token}"
-        return headers
-
     def iter_caption_stream(
         self,
         tenant_id: str,
         *,
         target_lang: str = "",
     ) -> Iterator[bytes]:
-        """Stream SSE caption events from ``/api/v1/translate/stream``."""
+        """Yield raw SSE bytes from ``/api/v1/translate/stream``."""
         params = {"tenant_id": tenant_id, "last_chunk_id": "0"}
         lang = (target_lang or "").strip()
         if lang:
             params["target_lang"] = lang
+        headers = {"Accept": "text/event-stream", "Cache-Control": "no-cache"}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
         url = self._url("/api/v1/translate/stream")
         try:
             resp = requests.get(
                 url,
-                headers=self._stream_headers(),
+                headers=headers,
                 params=params,
                 stream=True,
                 timeout=(self.timeout, None),
@@ -231,9 +228,6 @@ class SusiClient:
                 detail = resp.text
             raise SusiError(f"SUSI stream failed ({resp.status_code}): {detail}")
         try:
-            # ponytail: line-at-a-time passthrough so WSGI flushes each SSE event.
-            for line in resp.iter_lines(decode_unicode=False, delimiter=b"\n"):
-                if line is not None:
-                    yield line + b"\n"
+            yield from resp.iter_content(chunk_size=1024)
         finally:
             resp.close()

--- a/interpretation/susi.py
+++ b/interpretation/susi.py
@@ -196,6 +196,12 @@ class SusiClient:
         """Stop the grabber and release resources for a tenant."""
         return self._request("POST", f"/stop_event/{tenant_id}")
 
+    def _stream_headers(self) -> dict:
+        headers = {"Accept": "text/event-stream", "Cache-Control": "no-cache"}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+        return headers
+
     def iter_caption_stream(
         self,
         tenant_id: str,
@@ -203,7 +209,7 @@ class SusiClient:
         target_lang: str = "",
     ) -> Iterator[bytes]:
         """Stream SSE caption events from ``/api/v1/translate/stream``."""
-        params = {"tenant_id": tenant_id}
+        params = {"tenant_id": tenant_id, "last_chunk_id": "0"}
         lang = (target_lang or "").strip()
         if lang:
             params["target_lang"] = lang
@@ -211,7 +217,7 @@ class SusiClient:
         try:
             resp = requests.get(
                 url,
-                headers=self._headers(),
+                headers=self._stream_headers(),
                 params=params,
                 stream=True,
                 timeout=(self.timeout, None),
@@ -225,6 +231,9 @@ class SusiClient:
                 detail = resp.text
             raise SusiError(f"SUSI stream failed ({resp.status_code}): {detail}")
         try:
-            yield from resp.iter_content(chunk_size=None)
+            # ponytail: line-at-a-time passthrough so WSGI flushes each SSE event.
+            for line in resp.iter_lines(decode_unicode=False, delimiter=b"\n"):
+                if line is not None:
+                    yield line + b"\n"
         finally:
             resp.close()

--- a/interpretation/susi.py
+++ b/interpretation/susi.py
@@ -201,9 +201,13 @@ class SusiClient:
         tenant_id: str,
         *,
         target_lang: str = "",
+        last_chunk_id: str = "0",
     ) -> Iterator[bytes]:
         """Yield raw SSE bytes from ``/api/v1/translate/stream``."""
-        params = {"tenant_id": tenant_id, "last_chunk_id": "0"}
+        params = {
+            "tenant_id": tenant_id,
+            "last_chunk_id": str(last_chunk_id or "0"),
+        }
         lang = (target_lang or "").strip()
         if lang:
             params["target_lang"] = lang

--- a/interpretation/susi.py
+++ b/interpretation/susi.py
@@ -8,14 +8,16 @@ Bearer token to avoid cookie CSRF handling.
 Relevant SUSI endpoints used here:
     GET  /auth/api/status     -> {"authenticated": bool, "email", "name"}
     POST /auth/api/login      -> sets JWT cookie, body {status,email,name}
-    POST /session             -> {"tenant_id", "source"}
+    POST /session                        -> {"tenant_id", "source"}
     POST /api/v1/translate/configure
     GET  /api/v1/translate/status/<tenant_id>
+    GET  /api/v1/translate/stream        -> SSE captions (tenant_id, target_lang)
     POST /stop_event/<tenant_id>
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from urllib.parse import urljoin
 
@@ -150,9 +152,12 @@ class SusiClient:
 
     # -- session lifecycle (used by later milestones) -------------------
 
-    def create_session(self, source: str = "youtube") -> str:
+    def create_session(self, source: str = "youtube", *, name: str = "") -> str:
         """Mint a tenant/session ID for a given audio source."""
-        result = self._request("POST", "/session", json={"source": source})
+        payload: dict = {"source": source}
+        if name:
+            payload["name"] = name
+        result = self._request("POST", "/session", json=payload)
         if not result.ok:
             raise SusiError(f"Failed to create SUSI session: {result.data}")
         tenant_id = result.data.get("tenant_id")
@@ -165,7 +170,7 @@ class SusiClient:
         tenant_id: str,
         *,
         stream_url: str = "",
-        stream_type: str = "youtube",
+        stream_type: str = "platform",
         transcription: dict | None = None,
         translation: dict | None = None,
     ) -> SusiResult:
@@ -177,7 +182,6 @@ class SusiClient:
             payload["translation"] = translation
         if stream_url:
             payload["stream_url"] = stream_url
-            # SUSI reads ``stream_type`` (defaults to ``youtube`` if omitted).
             payload["stream_type"] = stream_type
         result = self._request("POST", "/api/v1/translate/configure", json=payload)
         if not result.ok:
@@ -192,7 +196,35 @@ class SusiClient:
         """Stop the grabber and release resources for a tenant."""
         return self._request("POST", f"/stop_event/{tenant_id}")
 
-    def latest_transcript(self, tenant_id: str, sentences: bool = True) -> SusiResult:
-        """Fetch the most recent transcript for a tenant (non-destructive)."""
-        params = {"tenant_id": tenant_id, "sentences": "true" if sentences else "false"}
-        return self._request("GET", "/transcripts/latest", params=params)
+    def iter_caption_stream(
+        self,
+        tenant_id: str,
+        *,
+        target_lang: str = "",
+    ) -> Iterator[bytes]:
+        """Stream SSE caption events from ``/api/v1/translate/stream``."""
+        params = {"tenant_id": tenant_id}
+        lang = (target_lang or "").strip()
+        if lang:
+            params["target_lang"] = lang
+        url = self._url("/api/v1/translate/stream")
+        try:
+            resp = requests.get(
+                url,
+                headers=self._headers(),
+                params=params,
+                stream=True,
+                timeout=(self.timeout, None),
+            )
+        except requests.RequestException as exc:
+            raise SusiError(f"Could not reach SUSI stream at {url}: {exc}") from exc
+        if not resp.ok:
+            try:
+                detail = resp.json()
+            except ValueError:
+                detail = resp.text
+            raise SusiError(f"SUSI stream failed ({resp.status_code}): {detail}")
+        try:
+            yield from resp.iter_content(chunk_size=None)
+        finally:
+            resp.close()

--- a/interpretation/susi_providers.py
+++ b/interpretation/susi_providers.py
@@ -1,15 +1,34 @@
-"""SUSI provider choices for organizer forms."""
+"""SUSI provider choices for organizer forms (voxbento_translator)."""
 
 from django.utils.translation import gettext_lazy as _
 
-# ponytail: static list; upgrade path is SUSI /providers API when exposed.
+DEFAULT_SUSI_TRANSCRIPTION_PROVIDER = "faster_whisper"
+DEFAULT_SUSI_TRANSLATION_PROVIDER = "nllb_ctranslate2"
+
+# ponytail: map pre-release stored values; drop after first prod deploy.
+_LEGACY_PROVIDER_ALIASES = {
+    "whisper_local": DEFAULT_SUSI_TRANSCRIPTION_PROVIDER,
+    "nllb_local": DEFAULT_SUSI_TRANSLATION_PROVIDER,
+}
+
 SUSI_TRANSCRIPTION_PROVIDERS = (
-    ("whisper_local", _("Whisper (local)")),
-    ("openai", _("OpenAI")),
-    ("deepgram", _("Deepgram")),
+    (DEFAULT_SUSI_TRANSCRIPTION_PROVIDER, _("Faster Whisper (local)")),
 )
 
 SUSI_TRANSLATION_PROVIDERS = (
-    ("nllb_local", _("NLLB (local)")),
-    ("openai", _("OpenAI")),
+    (DEFAULT_SUSI_TRANSLATION_PROVIDER, _("NLLB CTranslate2 (local)")),
 )
+
+
+def resolve_transcription_provider(name: str) -> str:
+    raw = (name or "").strip()
+    if not raw:
+        return DEFAULT_SUSI_TRANSCRIPTION_PROVIDER
+    return _LEGACY_PROVIDER_ALIASES.get(raw, raw)
+
+
+def resolve_translation_provider(name: str) -> str:
+    raw = (name or "").strip()
+    if not raw:
+        return DEFAULT_SUSI_TRANSLATION_PROVIDER
+    return _LEGACY_PROVIDER_ALIASES.get(raw, raw)

--- a/interpretation/templates/interpretation/caption_preview.html
+++ b/interpretation/templates/interpretation/caption_preview.html
@@ -122,19 +122,29 @@
                         return;
                     }
                     if (data.status === "connected") {
-                        statusLine.textContent = "{% trans 'Waiting for captions…'|escapejs %}";
+                        statusLine.textContent = "{% trans 'Connected — waiting for captions…'|escapejs %}";
                         statusLine.classList.remove("is-error");
                         return;
                     }
                     if (data.status === "error") {
                         statusLine.textContent = data.message || "{% trans 'Stream error.'|escapejs %}";
                         statusLine.classList.add("is-error");
+                        source.close();
                         return;
                     }
-                    showCaption(data.translation || data.transcript || "");
+                    var text = (data.translation || data.transcript || "").trim();
+                    showCaption(text);
+                };
+
+                source.onopen = function () {
+                    statusLine.textContent = "{% trans 'Connected — waiting for captions…'|escapejs %}";
+                    statusLine.classList.remove("is-error");
                 };
 
                 source.onerror = function () {
+                    if (source.readyState === EventSource.CLOSED) {
+                        return;
+                    }
                     statusLine.textContent = "{% trans 'Caption stream disconnected.'|escapejs %}";
                     statusLine.classList.add("is-error");
                 };

--- a/interpretation/templates/interpretation/caption_preview.html
+++ b/interpretation/templates/interpretation/caption_preview.html
@@ -103,17 +103,6 @@
                 var lastText = "";
                 var source = new EventSource(streamUrl);
 
-                function showCaption(text) {
-                    if (!text || text === lastText) {
-                        return;
-                    }
-                    lastText = text;
-                    captionBox.textContent = text;
-                    captionBox.classList.remove("interpretation-preview-caption-box--idle");
-                    statusLine.textContent = "{% trans 'Receiving captions.'|escapejs %}";
-                    statusLine.classList.remove("is-error");
-                }
-
                 source.onmessage = function (event) {
                     var data;
                     try {
@@ -133,20 +122,20 @@
                         return;
                     }
                     var text = (data.translation || data.transcript || "").trim();
-                    showCaption(text);
-                };
-
-                source.onopen = function () {
-                    statusLine.textContent = "{% trans 'Connected — waiting for captions…'|escapejs %}";
-                    statusLine.classList.remove("is-error");
+                    if (text && text !== lastText) {
+                        lastText = text;
+                        captionBox.textContent = text;
+                        captionBox.classList.remove("interpretation-preview-caption-box--idle");
+                        statusLine.textContent = "{% trans 'Receiving captions.'|escapejs %}";
+                        statusLine.classList.remove("is-error");
+                    }
                 };
 
                 source.onerror = function () {
-                    if (source.readyState === EventSource.CLOSED) {
-                        return;
+                    if (source.readyState !== EventSource.CLOSED) {
+                        statusLine.textContent = "{% trans 'Caption stream disconnected.'|escapejs %}";
+                        statusLine.classList.add("is-error");
                     }
-                    statusLine.textContent = "{% trans 'Caption stream disconnected.'|escapejs %}";
-                    statusLine.classList.add("is-error");
                 };
             })();
         </script>

--- a/interpretation/templates/interpretation/caption_preview.html
+++ b/interpretation/templates/interpretation/caption_preview.html
@@ -97,40 +97,47 @@
     {% if preview_supported and is_running %}
         <script>
             (function () {
-                var pollUrl = "{{ poll_url|escapejs }}";
+                var streamUrl = "{{ stream_url|escapejs }}";
                 var statusLine = document.getElementById("preview-status-line");
                 var captionBox = document.getElementById("preview-caption-box");
                 var lastText = "";
+                var source = new EventSource(streamUrl);
 
-                function poll() {
-                    fetch(pollUrl, { credentials: "same-origin", headers: { Accept: "application/json" } })
-                        .then(function (response) { return response.json(); })
-                        .then(function (data) {
-                            if (data.error) {
-                                statusLine.textContent = data.error;
-                                statusLine.classList.add("is-error");
-                                return;
-                            }
-                            if (!data.running) {
-                                statusLine.textContent = "{% trans 'Session stopped.'|escapejs %}";
-                                return;
-                            }
-                            if (data.text && data.text !== lastText) {
-                                lastText = data.text;
-                                captionBox.textContent = data.text;
-                                captionBox.classList.remove("interpretation-preview-caption-box--idle");
-                                statusLine.textContent = "{% trans 'Receiving captions.'|escapejs %}";
-                                statusLine.classList.remove("is-error");
-                            }
-                        })
-                        .catch(function () {
-                            statusLine.textContent = "{% trans 'Could not load captions.'|escapejs %}";
-                            statusLine.classList.add("is-error");
-                        });
+                function showCaption(text) {
+                    if (!text || text === lastText) {
+                        return;
+                    }
+                    lastText = text;
+                    captionBox.textContent = text;
+                    captionBox.classList.remove("interpretation-preview-caption-box--idle");
+                    statusLine.textContent = "{% trans 'Receiving captions.'|escapejs %}";
+                    statusLine.classList.remove("is-error");
                 }
 
-                poll();
-                window.setInterval(poll, 2000);
+                source.onmessage = function (event) {
+                    var data;
+                    try {
+                        data = JSON.parse(event.data);
+                    } catch (err) {
+                        return;
+                    }
+                    if (data.status === "connected") {
+                        statusLine.textContent = "{% trans 'Waiting for captions…'|escapejs %}";
+                        statusLine.classList.remove("is-error");
+                        return;
+                    }
+                    if (data.status === "error") {
+                        statusLine.textContent = data.message || "{% trans 'Stream error.'|escapejs %}";
+                        statusLine.classList.add("is-error");
+                        return;
+                    }
+                    showCaption(data.translation || data.transcript || "");
+                };
+
+                source.onerror = function () {
+                    statusLine.textContent = "{% trans 'Caption stream disconnected.'|escapejs %}";
+                    statusLine.classList.add("is-error");
+                };
             })();
         </script>
     {% endif %}

--- a/interpretation/urls.py
+++ b/interpretation/urls.py
@@ -8,6 +8,7 @@ from .views import (
     InterpretationCaptionPreviewStream,
     InterpretationInterpreters,
     InterpretationOverview,
+    InterpretationRoomCaptions,
     InterpretationRoomSettings,
 )
 
@@ -44,5 +45,10 @@ urlpatterns = [
         _PREFIX + "rooms/<int:pk>/preview/stream/",
         InterpretationCaptionPreviewStream.as_view(),
         name="room.preview.stream",
+    ),
+    path(
+        _PREFIX + "rooms/<int:pk>/captions/",
+        InterpretationRoomCaptions.as_view(),
+        name="room.captions",
     ),
 ]

--- a/interpretation/urls.py
+++ b/interpretation/urls.py
@@ -5,7 +5,7 @@ from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
 from .api import RoomInterpretationViewSet
 from .views import (
     InterpretationCaptionPreview,
-    InterpretationCaptionPreviewPoll,
+    InterpretationCaptionPreviewStream,
     InterpretationInterpreters,
     InterpretationOverview,
     InterpretationRoomSettings,
@@ -41,8 +41,8 @@ urlpatterns = [
         name="room.preview",
     ),
     path(
-        _PREFIX + "rooms/<int:pk>/preview/poll/",
-        InterpretationCaptionPreviewPoll.as_view(),
-        name="room.preview.poll",
+        _PREFIX + "rooms/<int:pk>/preview/stream/",
+        InterpretationCaptionPreviewStream.as_view(),
+        name="room.preview.stream",
     ),
 ]

--- a/interpretation/utils.py
+++ b/interpretation/utils.py
@@ -15,8 +15,10 @@ NATIVE_LIVESTREAM = "livestream.native"
 YOUTUBE_LIVESTREAM = "livestream.youtube"
 IFRAME_LIVESTREAM = "livestream.iframe"
 
-# SUSI ``YouTubeSource``: yt-dlp for platform URLs, ffmpeg for direct ``.m3u8``.
-SUSI_STREAM_TYPE = "youtube"
+# configure ``stream_type``; SUSI rewrites ``.m3u8`` platform URLs to ``url`` itself.
+SUSI_STREAM_TYPE = "platform"
+# POST /session ``source`` (must stay in SUSI VALID_SOURCES).
+SUSI_SESSION_SOURCE = "youtube"
 
 # Embed-only schedules have no direct audio URL for SUSI to ingest.
 _SKIP_SCHEDULE_TYPES = frozenset({"iframe"})

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.http import JsonResponse
+from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -504,8 +504,8 @@ class InterpretationCaptionPreview(
             "is_running": is_running,
             "preview_supported": data.get("interpreter")
             == RoomInterpretation.INTERPRETER_SUSI,
-            "poll_url": reverse(
-                "plugins:interpretation:room.preview.poll",
+            "stream_url": reverse(
+                "plugins:interpretation:room.preview.stream",
                 kwargs={
                     "organizer": event.organizer.slug,
                     "event": event.slug,
@@ -518,33 +518,50 @@ class InterpretationCaptionPreview(
         }
 
 
-class InterpretationCaptionPreviewPoll(
+class InterpretationCaptionPreviewStream(
     InterpretationEnabledMixin,
     EventPermissionRequiredMixin,
     View,
 ):
-    """Temporary JSON poll endpoint for the caption preview page."""
+    """Proxy SUSI SSE captions for the organizer preview page."""
 
     permission = "can_change_event_settings"
     http_method_names = ["get"]
 
     def get(self, request, pk, *args, **kwargs):
+        import json
+
         room = get_object_or_404(
             request.event.rooms.filter(deleted=False),
             pk=pk,
         )
         interpretation, is_running = _preview_session(room, request.event)
         if interpretation is None or not is_running:
-            return JsonResponse({"running": False, "text": "", "error": ""})
+            return JsonResponse(
+                {"status": "error", "message": str(_("Session is not running."))},
+                status=409,
+            )
 
         client = get_susi_client(request.event)
-        try:
-            result = client.latest_transcript(interpretation.backend_session_id)
-            if not result.ok:
-                return JsonResponse(
-                    {"running": True, "text": "", "error": str(result.data)}
+        tenant_id = interpretation.backend_session_id
+        target_lang = ""
+        if interpretation.target_languages:
+            target_lang = interpretation.target_languages[0]
+
+        def event_stream():
+            try:
+                yield from client.iter_caption_stream(
+                    tenant_id,
+                    target_lang=target_lang,
                 )
-            text = _preview_caption_text(result.data)
-            return JsonResponse({"running": True, "text": text, "error": ""})
-        except SusiError as exc:
-            return JsonResponse({"running": True, "text": "", "error": str(exc)})
+            except SusiError as exc:
+                payload = json.dumps({"status": "error", "message": str(exc)})
+                yield f"data: {payload}\n\n".encode()
+
+        response = StreamingHttpResponse(
+            event_stream(),
+            content_type="text/event-stream",
+        )
+        response["Cache-Control"] = "no-cache"
+        response["X-Accel-Buffering"] = "no"
+        return response

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -1,7 +1,7 @@
 from asgiref.sync import sync_to_async
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
-from django.http import StreamingHttpResponse
+from django.http import Http404, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -541,16 +541,41 @@ def _preview_stream_response(stream) -> StreamingHttpResponse:
     return response
 
 
-def _load_preview_stream(event, pk):
-    """Sync ORM/auth lookup for preview stream (call via sync_to_async)."""
+def _load_caption_stream(
+    event,
+    pk,
+    *,
+    target_lang: str = "",
+    last_chunk_id: str = "0",
+):
+    """Sync ORM lookup for caption SSE (organizer preview or attendee room)."""
     room = get_object_or_404(event.rooms.filter(deleted=False), pk=pk)
     interpretation, is_running = _preview_session(room, event)
     if interpretation is None or not is_running:
         return None, None, str(_("Session is not running."))
+    lang = (target_lang or "").strip()
+    languages = list(interpretation.target_languages or [])
+    if lang and languages and lang not in languages:
+        return None, None, str(_("Unknown caption language for this room."))
     client = get_susi_client(event)
     if not client.auth_token:
         return None, None, str(_("SUSI is not connected for this event."))
-    return client, interpretation.backend_session_id, None
+    return (
+        client,
+        {
+            "tenant_id": interpretation.backend_session_id,
+            "target_lang": lang,
+            "last_chunk_id": str(last_chunk_id or "0"),
+        },
+        None,
+    )
+
+
+def _load_preview_stream(event, pk):
+    client, stream_args, error = _load_caption_stream(event, pk)
+    if error:
+        return None, None, error
+    return client, stream_args["tenant_id"], None
 
 
 class InterpretationCaptionPreviewStream(View):
@@ -593,3 +618,32 @@ class InterpretationCaptionPreviewStream(View):
         if error:
             return _preview_sse(error, error=True)
         return _preview_stream_response(stream_susi_captions_async(client, tenant_id))
+
+
+class InterpretationRoomCaptions(View):
+    """Relay SUSI captions to video attendees as same-origin SSE."""
+
+    http_method_names = ["get"]
+
+    async def get(self, request, pk, *args, **kwargs):
+        if PLUGIN_MODULE not in request.event.get_plugins():
+            raise Http404("Interpretation is not enabled for this event.")
+        client, stream_args, error = await sync_to_async(
+            _load_caption_stream,
+            thread_sensitive=True,
+        )(
+            request.event,
+            pk,
+            target_lang=request.GET.get("lang", ""),
+            last_chunk_id=request.GET.get("last_chunk_id", "0"),
+        )
+        if error:
+            return _preview_sse(error, error=True)
+        return _preview_stream_response(
+            stream_susi_captions_async(
+                client,
+                stream_args["tenant_id"],
+                target_lang=stream_args["target_lang"],
+                last_chunk_id=stream_args["last_chunk_id"],
+            )
+        )

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -1,3 +1,4 @@
+from asgiref.sync import sync_to_async
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.http import StreamingHttpResponse
@@ -5,7 +6,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views import View
-from asgiref.sync import sync_to_async
 from eventyay.control.permissions import EventPermissionRequiredMixin
 from eventyay.control.views.event import EventSettingsViewMixin
 
@@ -33,6 +33,7 @@ from .interpreter_credentials import (
     is_interpreter_configured,
 )
 from .models import RoomInterpretation
+from .preview_stream import stream_susi_captions_async
 from .room_control import (
     clear_room_interpretation_setup,
     get_interpretation,
@@ -42,7 +43,6 @@ from .room_control import (
     stop_room_session,
     update_room_interpretation,
 )
-from .preview_stream import stream_susi_captions_async
 
 PLUGIN_MODULE = "interpretation"
 

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -524,9 +524,7 @@ def _preview_sse(message: str, *, error: bool = False) -> StreamingHttpResponse:
     import json
 
     payload = (
-        {"status": "error", "message": message}
-        if error
-        else {"status": "connected"}
+        {"status": "error", "message": message} if error else {"status": "connected"}
     )
     body = f"data: {json.dumps(payload)}\n\n".encode()
     return StreamingHttpResponse(
@@ -594,6 +592,4 @@ class InterpretationCaptionPreviewStream(View):
         )(request.event, pk)
         if error:
             return _preview_sse(error, error=True)
-        return _preview_stream_response(
-            stream_susi_captions_async(client, tenant_id)
-        )
+        return _preview_stream_response(stream_susi_captions_async(client, tenant_id))

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -1,9 +1,11 @@
 from django.contrib import messages
-from django.http import JsonResponse, StreamingHttpResponse
+from django.core.exceptions import PermissionDenied
+from django.http import StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views import View
+from asgiref.sync import sync_to_async
 from eventyay.control.permissions import EventPermissionRequiredMixin
 from eventyay.control.views.event import EventSettingsViewMixin
 
@@ -40,7 +42,7 @@ from .room_control import (
     stop_room_session,
     update_room_interpretation,
 )
-from .susi import SusiError
+from .preview_stream import stream_susi_captions_async
 
 PLUGIN_MODULE = "interpretation"
 
@@ -495,14 +497,6 @@ class InterpretationCaptionPreview(
     def _context(self, request, event, room):
         interpretation, is_running = _preview_session(room, event)
         data = serialize_room_interpretation(room, event, interpretation)
-        stream_path = reverse(
-            "plugins:interpretation:room.preview.stream",
-            kwargs={
-                "organizer": event.organizer.slug,
-                "event": event.slug,
-                "pk": room.pk,
-            },
-        )
         return {
             "event": event,
             "room": room,
@@ -512,67 +506,94 @@ class InterpretationCaptionPreview(
             "is_running": is_running,
             "preview_supported": data.get("interpreter")
             == RoomInterpretation.INTERPRETER_SUSI,
-            "stream_url": request.build_absolute_uri(stream_path),
+            "stream_url": reverse(
+                "plugins:interpretation:room.preview.stream",
+                kwargs={
+                    "organizer": event.organizer.slug,
+                    "event": event.slug,
+                    "pk": room.pk,
+                },
+            ),
             "rooms_url": _rooms_url(event),
             "interpreters_url": _interpreters_url(event),
             "is_event_settings": True,
         }
 
 
-def _preview_sse_error(message: str) -> StreamingHttpResponse:
+def _preview_sse(message: str, *, error: bool = False) -> StreamingHttpResponse:
     import json
 
-    payload = json.dumps({"status": "error", "message": message})
+    payload = (
+        {"status": "error", "message": message}
+        if error
+        else {"status": "connected"}
+    )
+    body = f"data: {json.dumps(payload)}\n\n".encode()
     return StreamingHttpResponse(
-        [f"data: {payload}\n\n".encode()],
-        content_type="text/event-stream; charset=utf-8",
+        [body], content_type="text/event-stream; charset=utf-8"
     )
 
 
-class InterpretationCaptionPreviewStream(
-    InterpretationEnabledMixin,
-    EventPermissionRequiredMixin,
-    View,
-):
-    """Proxy SUSI SSE captions for the organizer preview page."""
+def _preview_stream_response(stream) -> StreamingHttpResponse:
+    response = StreamingHttpResponse(
+        stream, content_type="text/event-stream; charset=utf-8"
+    )
+    response["Cache-Control"] = "no-cache, no-transform"
+    response["X-Accel-Buffering"] = "no"
+    return response
+
+
+def _load_preview_stream(event, pk):
+    """Sync ORM/auth lookup for preview stream (call via sync_to_async)."""
+    room = get_object_or_404(event.rooms.filter(deleted=False), pk=pk)
+    interpretation, is_running = _preview_session(room, event)
+    if interpretation is None or not is_running:
+        return None, None, str(_("Session is not running."))
+    client = get_susi_client(event)
+    if not client.auth_token:
+        return None, None, str(_("SUSI is not connected for this event."))
+    return client, interpretation.backend_session_id, None
+
+
+class InterpretationCaptionPreviewStream(View):
+    """Proxy SUSI caption SSE to the organizer preview page (async for Daphne)."""
 
     permission = "can_change_event_settings"
     http_method_names = ["get"]
 
-    def get(self, request, pk, *args, **kwargs):
-        import json
+    async def dispatch(self, request, *args, **kwargs):
+        if PLUGIN_MODULE not in request.event.get_plugins():
+            return redirect(
+                "eventyay_common:event.plugins",
+                organizer=request.event.organizer.slug,
+                event=request.event.slug,
+            )
+        if not request.user.is_authenticated:
+            raise PermissionDenied()
+        allowed = await sync_to_async(
+            request.user.has_event_permission,
+            thread_sensitive=True,
+        )(request.organizer, request.event, self.permission, request=request)
+        if not allowed:
+            raise PermissionDenied(
+                _("You do not have permission to view this content.")
+            )
+        self.setup(request, *args, **kwargs)
+        method = request.method.lower()
+        if method not in self.http_method_names:
+            return await self.http_method_not_allowed(request, *args, **kwargs)
+        handler = getattr(self, method, None)
+        if handler is None:
+            return await self.http_method_not_allowed(request, *args, **kwargs)
+        return await handler(request, *args, **kwargs)
 
-        room = get_object_or_404(
-            request.event.rooms.filter(deleted=False),
-            pk=pk,
+    async def get(self, request, pk, *args, **kwargs):
+        client, tenant_id, error = await sync_to_async(
+            _load_preview_stream,
+            thread_sensitive=True,
+        )(request.event, pk)
+        if error:
+            return _preview_sse(error, error=True)
+        return _preview_stream_response(
+            stream_susi_captions_async(client, tenant_id)
         )
-        interpretation, is_running = _preview_session(room, request.event)
-        if interpretation is None or not is_running:
-            return _preview_sse_error(str(_("Session is not running.")))
-
-        client = get_susi_client(request.event)
-        if not client.auth_token:
-            return _preview_sse_error(str(_("SUSI is not connected for this event.")))
-
-        tenant_id = interpretation.backend_session_id
-        # Preview shows source transcript; per-language translation comes later in video UI.
-        target_lang = ""
-
-        def event_stream():
-            yield b": stream-open\n\n"
-            try:
-                yield from client.iter_caption_stream(
-                    tenant_id,
-                    target_lang=target_lang,
-                )
-            except SusiError as exc:
-                payload = json.dumps({"status": "error", "message": str(exc)})
-                yield f"data: {payload}\n\n".encode()
-
-        response = StreamingHttpResponse(
-            event_stream(),
-            content_type="text/event-stream; charset=utf-8",
-        )
-        response["Cache-Control"] = "no-cache, no-transform"
-        response["X-Accel-Buffering"] = "no"
-        return response

--- a/interpretation/views.py
+++ b/interpretation/views.py
@@ -444,7 +444,7 @@ class InterpretationCaptionPreview(
     def get(self, request, pk, *args, **kwargs):
         event = request.event
         room = self._room(event, pk)
-        return render(request, self.template_name, self._context(event, room))
+        return render(request, self.template_name, self._context(request, event, room))
 
     def post(self, request, pk, *args, **kwargs):
         event = request.event
@@ -492,9 +492,17 @@ class InterpretationCaptionPreview(
 
         return redirect(redirect_url)
 
-    def _context(self, event, room):
+    def _context(self, request, event, room):
         interpretation, is_running = _preview_session(room, event)
         data = serialize_room_interpretation(room, event, interpretation)
+        stream_path = reverse(
+            "plugins:interpretation:room.preview.stream",
+            kwargs={
+                "organizer": event.organizer.slug,
+                "event": event.slug,
+                "pk": room.pk,
+            },
+        )
         return {
             "event": event,
             "room": room,
@@ -504,18 +512,21 @@ class InterpretationCaptionPreview(
             "is_running": is_running,
             "preview_supported": data.get("interpreter")
             == RoomInterpretation.INTERPRETER_SUSI,
-            "stream_url": reverse(
-                "plugins:interpretation:room.preview.stream",
-                kwargs={
-                    "organizer": event.organizer.slug,
-                    "event": event.slug,
-                    "pk": room.pk,
-                },
-            ),
+            "stream_url": request.build_absolute_uri(stream_path),
             "rooms_url": _rooms_url(event),
             "interpreters_url": _interpreters_url(event),
             "is_event_settings": True,
         }
+
+
+def _preview_sse_error(message: str) -> StreamingHttpResponse:
+    import json
+
+    payload = json.dumps({"status": "error", "message": message})
+    return StreamingHttpResponse(
+        [f"data: {payload}\n\n".encode()],
+        content_type="text/event-stream; charset=utf-8",
+    )
 
 
 class InterpretationCaptionPreviewStream(
@@ -537,18 +548,18 @@ class InterpretationCaptionPreviewStream(
         )
         interpretation, is_running = _preview_session(room, request.event)
         if interpretation is None or not is_running:
-            return JsonResponse(
-                {"status": "error", "message": str(_("Session is not running."))},
-                status=409,
-            )
+            return _preview_sse_error(str(_("Session is not running.")))
 
         client = get_susi_client(request.event)
+        if not client.auth_token:
+            return _preview_sse_error(str(_("SUSI is not connected for this event.")))
+
         tenant_id = interpretation.backend_session_id
+        # Preview shows source transcript; per-language translation comes later in video UI.
         target_lang = ""
-        if interpretation.target_languages:
-            target_lang = interpretation.target_languages[0]
 
         def event_stream():
+            yield b": stream-open\n\n"
             try:
                 yield from client.iter_caption_stream(
                     tenant_id,
@@ -560,8 +571,8 @@ class InterpretationCaptionPreviewStream(
 
         response = StreamingHttpResponse(
             event_stream(),
-            content_type="text/event-stream",
+            content_type="text/event-stream; charset=utf-8",
         )
-        response["Cache-Control"] = "no-cache"
+        response["Cache-Control"] = "no-cache, no-transform"
         response["X-Accel-Buffering"] = "no"
         return response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,15 +70,15 @@ def test_api_config_patch(organizer_client, connected_event, room):
             "interpreter": RoomInterpretation.INTERPRETER_SUSI,
             "room_enabled": True,
             "target_languages": ["fr", "de"],
-            "transcription_provider": "whisper_local",
-            "translation_provider": "nllb_local",
+            "transcription_provider": "faster_whisper",
+            "translation_provider": "nllb_ctranslate2",
         },
     )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["target_languages"] == ["fr", "de"]
-    assert payload["transcription_provider"] == "whisper_local"
+    assert payload["transcription_provider"] == "faster_whisper"
 
 
 def test_api_config_patch_ignores_credential_keys(
@@ -120,8 +120,8 @@ def test_api_start_and_stop(organizer_client, connected_event, room, monkeypatch
         room=room,
         interpreter=RoomInterpretation.INTERPRETER_SUSI,
         room_enabled=True,
-        transcription_provider="whisper_local",
-        translation_provider="nllb_local",
+        transcription_provider="faster_whisper",
+        translation_provider="nllb_ctranslate2",
         target_languages=["en"],
     )
 

--- a/tests/test_caption_preview.py
+++ b/tests/test_caption_preview.py
@@ -1,11 +1,12 @@
 """Tests for the temporary caption preview page."""
 
+import json
+
 import pytest
 from django.urls import reverse
 
 from interpretation.models import RoomInterpretation
 from interpretation.room_control import SessionResult
-from interpretation.susi import SusiResult
 
 pytestmark = pytest.mark.django_db
 
@@ -28,9 +29,9 @@ def preview_url(event, room):
     )
 
 
-def preview_poll_url(event, room):
+def preview_stream_url(event, room):
     return reverse(
-        "plugins:interpretation:room.preview.poll",
+        "plugins:interpretation:room.preview.stream",
         kwargs={
             "organizer": event.organizer.slug,
             "event": event.slug,
@@ -60,7 +61,24 @@ def test_preview_page_is_simple(organizer_client, connected_event, room):
     assert "Session ID" not in content
 
 
-def test_preview_poll_requires_running_session(organizer_client, connected_event, room):
+def test_preview_page_includes_sse_when_running(organizer_client, connected_event, room):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+        status=RoomInterpretation.STATUS_RUNNING,
+        backend_session_id="tenant-1",
+    )
+
+    response = organizer_client.get(preview_url(connected_event, room))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "EventSource" in content
+    assert "preview/stream" in content
+
+
+def test_preview_stream_requires_running_session(organizer_client, connected_event, room):
     RoomInterpretation.objects.create(
         room=room,
         interpreter=RoomInterpretation.INTERPRETER_SUSI,
@@ -68,10 +86,10 @@ def test_preview_poll_requires_running_session(organizer_client, connected_event
         status=RoomInterpretation.STATUS_IDLE,
     )
 
-    response = organizer_client.get(preview_poll_url(connected_event, room))
+    response = organizer_client.get(preview_stream_url(connected_event, room))
 
-    assert response.status_code == 200
-    assert response.json() == {"running": False, "text": "", "error": ""}
+    assert response.status_code == 409
+    assert response.json()["status"] == "error"
 
 
 def test_preview_treats_legacy_stopped_status_as_not_running(
@@ -85,52 +103,46 @@ def test_preview_treats_legacy_stopped_status_as_not_running(
         backend_session_id="stale-tenant",
     )
 
-    response = organizer_client.get(preview_poll_url(connected_event, room))
+    response = organizer_client.get(preview_stream_url(connected_event, room))
 
-    assert response.status_code == 200
-    assert response.json() == {"running": False, "text": "", "error": ""}
+    assert response.status_code == 409
 
 
-def test_preview_poll_returns_transcript(
-    organizer_client, connected_event, room, monkeypatch
-):
+def test_preview_stream_proxies_sse(organizer_client, connected_event, room, monkeypatch):
     RoomInterpretation.objects.create(
         room=room,
         interpreter=RoomInterpretation.INTERPRETER_SUSI,
         room_enabled=True,
         status=RoomInterpretation.STATUS_RUNNING,
         backend_session_id="tenant-1",
+        target_languages=["de"],
     )
 
     class FakeClient:
-        def latest_transcript(self, tenant_id):
+        def iter_caption_stream(self, tenant_id, *, target_lang=""):
             assert tenant_id == "tenant-1"
-            return SusiResult(
-                ok=True,
-                status_code=200,
-                data={"transcript": "hello world"},
-            )
+            assert target_lang == "de"
+            payload = json.dumps({"transcript": "hello world", "translation": "hallo"})
+            yield f"data: {payload}\n\n".encode()
 
     monkeypatch.setattr(
         "interpretation.views.get_susi_client",
         lambda event: FakeClient(),
     )
 
-    response = organizer_client.get(preview_poll_url(connected_event, room))
+    response = organizer_client.get(preview_stream_url(connected_event, room))
 
     assert response.status_code == 200
-    assert response.json() == {
-        "running": True,
-        "text": "hello world",
-        "error": "",
-    }
+    assert response["Content-Type"] == "text/event-stream"
+    body = b"".join(response.streaming_content)
+    assert b"hello world" in body
 
 
 def _preview_settings_post():
     return {
         "preview_action": "start",
-        "transcription_provider": "whisper_local",
-        "translation_provider": "nllb_local",
+        "transcription_provider": "faster_whisper",
+        "translation_provider": "nllb_ctranslate2",
     }
 
 
@@ -145,15 +157,15 @@ def test_preview_save_settings(organizer_client, connected_event, room):
         preview_url(connected_event, room),
         {
             "preview_action": "save_settings",
-            "transcription_provider": "whisper_local",
-            "translation_provider": "nllb_local",
+            "transcription_provider": "faster_whisper",
+            "translation_provider": "nllb_ctranslate2",
         },
     )
 
     assert response.status_code == 302
     interpretation = RoomInterpretation.objects.get(room=room)
-    assert interpretation.transcription_provider == "whisper_local"
-    assert interpretation.translation_provider == "nllb_local"
+    assert interpretation.transcription_provider == "faster_whisper"
+    assert interpretation.translation_provider == "nllb_ctranslate2"
 
 
 def test_preview_start_action(organizer_client, connected_event, room, monkeypatch):
@@ -175,7 +187,7 @@ def test_preview_start_action(organizer_client, connected_event, room, monkeypat
 
     assert response.status_code == 302
     interpretation.refresh_from_db()
-    assert interpretation.transcription_provider == "whisper_local"
+    assert interpretation.transcription_provider == "faster_whisper"
 
 
 def test_preview_caption_text_uses_transcript():

--- a/tests/test_caption_preview.py
+++ b/tests/test_caption_preview.py
@@ -55,6 +55,17 @@ def preview_stream_url(event, room):
     )
 
 
+def room_captions_url(event, room):
+    return reverse(
+        "plugins:interpretation:room.captions",
+        kwargs={
+            "organizer": event.organizer.slug,
+            "event": event.slug,
+            "pk": room.pk,
+        },
+    )
+
+
 def test_preview_page_is_simple(organizer_client, connected_event, room):
     RoomInterpretation.objects.create(
         room=room,
@@ -161,6 +172,59 @@ def test_preview_stream_proxies_sse(
     body = _sse_body(response)
     assert b": stream-open" in body
     assert b"hello world" in body
+
+
+def test_room_captions_stream_requires_running_session(
+    organizer_client, connected_event, room
+):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+        status=RoomInterpretation.STATUS_IDLE,
+    )
+
+    response = organizer_client.get(room_captions_url(connected_event, room))
+
+    assert response.status_code == 200
+    assert b"Session is not running" in _sse_body(response)
+
+
+def test_room_captions_stream_proxies_with_lang(
+    organizer_client, connected_event, room, monkeypatch
+):
+    RoomInterpretation.objects.create(
+        room=room,
+        interpreter=RoomInterpretation.INTERPRETER_SUSI,
+        room_enabled=True,
+        status=RoomInterpretation.STATUS_RUNNING,
+        backend_session_id="tenant-1",
+        target_languages=["de", "fr"],
+    )
+
+    class FakeClient:
+        auth_token = "tok"
+
+        def iter_caption_stream(self, tenant_id, *, target_lang="", last_chunk_id="0"):
+            assert tenant_id == "tenant-1"
+            assert target_lang == "de"
+            assert last_chunk_id == "5"
+            payload = json.dumps(
+                {"transcript": "hello", "translation": "hallo", "chunk_id": 6}
+            )
+            yield f"data: {payload}\n\n".encode()
+
+    monkeypatch.setattr(
+        "interpretation.views.get_susi_client",
+        lambda event: FakeClient(),
+    )
+
+    response = organizer_client.get(
+        room_captions_url(connected_event, room) + "?lang=de&last_chunk_id=5"
+    )
+
+    assert response.status_code == 200
+    assert b"hallo" in _sse_body(response)
 
 
 def _preview_settings_post():

--- a/tests/test_caption_preview.py
+++ b/tests/test_caption_preview.py
@@ -3,12 +3,27 @@
 import json
 
 import pytest
+from asgiref.sync import async_to_sync
 from django.urls import reverse
 
 from interpretation.models import RoomInterpretation
 from interpretation.room_control import SessionResult
 
 pytestmark = pytest.mark.django_db
+
+
+def _sse_body(response) -> bytes:
+    stream = response.streaming_content
+    if hasattr(stream, "__aiter__"):
+
+        async def _collect() -> bytes:
+            chunks = []
+            async for chunk in stream:
+                chunks.append(chunk)
+            return b"".join(chunks)
+
+        return async_to_sync(_collect)()
+    return b"".join(stream)
 
 
 @pytest.fixture
@@ -90,7 +105,7 @@ def test_preview_stream_requires_running_session(organizer_client, connected_eve
 
     assert response.status_code == 200
     assert response["Content-Type"].startswith("text/event-stream")
-    body = b"".join(response.streaming_content).decode()
+    body = _sse_body(response).decode()
     assert "Session is not running" in body
 
 
@@ -108,7 +123,7 @@ def test_preview_treats_legacy_stopped_status_as_not_running(
     response = organizer_client.get(preview_stream_url(connected_event, room))
 
     assert response.status_code == 200
-    assert b"Session is not running" in b"".join(response.streaming_content)
+    assert b"Session is not running" in _sse_body(response)
 
 
 def test_preview_stream_proxies_sse(organizer_client, connected_event, room, monkeypatch):
@@ -118,7 +133,6 @@ def test_preview_stream_proxies_sse(organizer_client, connected_event, room, mon
         room_enabled=True,
         status=RoomInterpretation.STATUS_RUNNING,
         backend_session_id="tenant-1",
-        target_languages=["de"],
     )
 
     class FakeClient:
@@ -126,7 +140,6 @@ def test_preview_stream_proxies_sse(organizer_client, connected_event, room, mon
 
         def iter_caption_stream(self, tenant_id, *, target_lang=""):
             assert tenant_id == "tenant-1"
-            assert target_lang == ""
             payload = json.dumps({"transcript": "hello world", "translation": "hallo"})
             yield f"data: {payload}\n\n".encode()
 
@@ -139,7 +152,8 @@ def test_preview_stream_proxies_sse(organizer_client, connected_event, room, mon
 
     assert response.status_code == 200
     assert response["Content-Type"].startswith("text/event-stream")
-    body = b"".join(response.streaming_content)
+    body = _sse_body(response)
+    assert b": stream-open" in body
     assert b"hello world" in body
 
 

--- a/tests/test_caption_preview.py
+++ b/tests/test_caption_preview.py
@@ -88,8 +88,10 @@ def test_preview_stream_requires_running_session(organizer_client, connected_eve
 
     response = organizer_client.get(preview_stream_url(connected_event, room))
 
-    assert response.status_code == 409
-    assert response.json()["status"] == "error"
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/event-stream")
+    body = b"".join(response.streaming_content).decode()
+    assert "Session is not running" in body
 
 
 def test_preview_treats_legacy_stopped_status_as_not_running(
@@ -105,7 +107,8 @@ def test_preview_treats_legacy_stopped_status_as_not_running(
 
     response = organizer_client.get(preview_stream_url(connected_event, room))
 
-    assert response.status_code == 409
+    assert response.status_code == 200
+    assert b"Session is not running" in b"".join(response.streaming_content)
 
 
 def test_preview_stream_proxies_sse(organizer_client, connected_event, room, monkeypatch):
@@ -119,9 +122,11 @@ def test_preview_stream_proxies_sse(organizer_client, connected_event, room, mon
     )
 
     class FakeClient:
+        auth_token = "tok"
+
         def iter_caption_stream(self, tenant_id, *, target_lang=""):
             assert tenant_id == "tenant-1"
-            assert target_lang == "de"
+            assert target_lang == ""
             payload = json.dumps({"transcript": "hello world", "translation": "hallo"})
             yield f"data: {payload}\n\n".encode()
 
@@ -133,7 +138,7 @@ def test_preview_stream_proxies_sse(organizer_client, connected_event, room, mon
     response = organizer_client.get(preview_stream_url(connected_event, room))
 
     assert response.status_code == 200
-    assert response["Content-Type"] == "text/event-stream"
+    assert response["Content-Type"].startswith("text/event-stream")
     body = b"".join(response.streaming_content)
     assert b"hello world" in body
 

--- a/tests/test_caption_preview.py
+++ b/tests/test_caption_preview.py
@@ -76,7 +76,9 @@ def test_preview_page_is_simple(organizer_client, connected_event, room):
     assert "Session ID" not in content
 
 
-def test_preview_page_includes_sse_when_running(organizer_client, connected_event, room):
+def test_preview_page_includes_sse_when_running(
+    organizer_client, connected_event, room
+):
     RoomInterpretation.objects.create(
         room=room,
         interpreter=RoomInterpretation.INTERPRETER_SUSI,
@@ -93,7 +95,9 @@ def test_preview_page_includes_sse_when_running(organizer_client, connected_even
     assert "preview/stream" in content
 
 
-def test_preview_stream_requires_running_session(organizer_client, connected_event, room):
+def test_preview_stream_requires_running_session(
+    organizer_client, connected_event, room
+):
     RoomInterpretation.objects.create(
         room=room,
         interpreter=RoomInterpretation.INTERPRETER_SUSI,
@@ -126,7 +130,9 @@ def test_preview_treats_legacy_stopped_status_as_not_running(
     assert b"Session is not running" in _sse_body(response)
 
 
-def test_preview_stream_proxies_sse(organizer_client, connected_event, room, monkeypatch):
+def test_preview_stream_proxies_sse(
+    organizer_client, connected_event, room, monkeypatch
+):
     RoomInterpretation.objects.create(
         room=room,
         interpreter=RoomInterpretation.INTERPRETER_SUSI,

--- a/tests/test_preview_settings.py
+++ b/tests/test_preview_settings.py
@@ -9,14 +9,14 @@ from interpretation.forms import (
 def test_preview_settings_payload_maps_providers():
     form = CaptionPreviewSettingsForm(
         data={
-            "transcription_provider": "whisper_local",
-            "translation_provider": "nllb_local",
+            "transcription_provider": "faster_whisper",
+            "translation_provider": "nllb_ctranslate2",
         }
     )
     assert form.is_valid(), form.errors
     assert preview_settings_payload(form) == {
-        "transcription_provider": "whisper_local",
-        "translation_provider": "nllb_local",
+        "transcription_provider": "faster_whisper",
+        "translation_provider": "nllb_ctranslate2",
     }
 
 

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -4,6 +4,7 @@ import pytest
 
 from interpretation.services import start_stream_session
 from interpretation.utils import (
+    SUSI_SESSION_SOURCE,
     SUSI_STREAM_TYPE,
     get_module_stream_url,
     get_room_stream_url,
@@ -159,37 +160,50 @@ class RecordingClient:
         return None
 
 
-def test_start_stream_session_uses_susi_youtube_source():
+def test_start_stream_session_uses_platform_stream_type():
     client = RecordingClient()
     tenant = start_stream_session(
         client,
         "https://vs-hls-push-ww-live.akamaized.net/x/master.m3u8",
-        transcription_provider="whisper_local",
-        translation_provider="nllb_local",
+        transcription_provider="faster_whisper",
+        translation_provider="nllb_ctranslate2",
         source_language="en",
         target_languages=["de", "fr"],
     )
     assert tenant == "tenant-1"
-    assert client.calls[0] == ("create_session", SUSI_STREAM_TYPE)
+    assert client.calls[0] == ("create_session", SUSI_SESSION_SOURCE)
     name, tenant_id, kwargs = client.calls[1]
     assert name == "configure"
     assert tenant_id == "tenant-1"
     assert kwargs["stream_url"].endswith("master.m3u8")
     assert kwargs["stream_type"] == SUSI_STREAM_TYPE
-    assert kwargs["transcription"] == {"provider_name": "whisper_local"}
+    assert kwargs["transcription"] == {"provider_name": "faster_whisper"}
     assert kwargs["translation"] == {
-        "provider_name": "nllb_local",
+        "provider_name": "nllb_ctranslate2",
         "source_lang": "en",
         "target_lang": "de",
     }
 
 
-def test_start_stream_session_omits_empty_providers():
+def test_start_stream_session_defaults_empty_providers():
     client = RecordingClient()
     start_stream_session(client, "https://www.youtube.com/watch?v=abc")
     _, _, kwargs = client.calls[1]
-    assert kwargs["transcription"] is None
-    assert kwargs["translation"] is None
+    assert kwargs["transcription"] == {"provider_name": "faster_whisper"}
+    assert kwargs["translation"] == {"provider_name": "nllb_ctranslate2"}
+
+
+def test_start_stream_session_maps_legacy_provider_names():
+    client = RecordingClient()
+    start_stream_session(
+        client,
+        "https://www.youtube.com/watch?v=abc",
+        transcription_provider="whisper_local",
+        translation_provider="nllb_local",
+    )
+    _, _, kwargs = client.calls[1]
+    assert kwargs["transcription"] == {"provider_name": "faster_whisper"}
+    assert kwargs["translation"] == {"provider_name": "nllb_ctranslate2"}
 
 
 def test_start_stream_session_requires_stream_url():
@@ -210,7 +224,7 @@ def test_start_stream_session_rolls_back_on_configure_failure():
     client = FailingClient()
     with pytest.raises(SusiError):
         start_stream_session(client, "https://www.youtube.com/watch?v=abc")
-    assert client.calls[0] == ("create_session", SUSI_STREAM_TYPE)
+    assert client.calls[0] == ("create_session", SUSI_SESSION_SOURCE)
     assert ("stop_session", "tenant-1") in client.calls
 
 


### PR DESCRIPTION
## Summary by Sourcery

Switch caption preview from polling JSON to server-sent event streaming and add attendee-facing caption relay, while aligning SUSI session configuration and provider defaults.

New Features:
- Provide an SSE-based caption stream endpoint for organizer preview pages.
- Expose a room captions SSE endpoint for video attendees with language selection and chunk resumption.

Enhancements:
- Update caption preview UI to consume SSE streams with improved connection and error handling messaging.
- Introduce an async SSE relay layer around SUSI caption streams for compatibility with Daphne and proxies.
- Adjust SUSI client and utilities to use platform ingest, explicit session source, and caption streaming API.
- Default SUSI transcription/translation providers to Faster Whisper and NLLB CTranslate2 and map legacy provider names in forms and services.

Tests:
- Extend and adapt caption preview, room streaming, API, room service, and preview settings tests to cover SSE streaming behavior, provider defaults, and legacy provider mapping.