### PR TITLE
Fix AttributeError and unexpected keyword argument 'current_stream' in room_config

### DIFF
--- a/interpretation/video_integration.py
+++ b/interpretation/video_integration.py
@@ -8,7 +8,9 @@ from .settings import use_plugin_language_streams
 
 
 def augment_room_config(room, room_config: dict) -> None:
-    event = room.event
+    event = getattr(room, 'event', None)
+    if event is None:
+        return
     if not plugin_enabled(event):
         return
     flag_on = use_plugin_language_streams(event)
@@ -30,8 +32,8 @@ def install_video_integration() -> None:
 
     original_get_room_config = event_service.get_room_config
 
-    def get_room_config(room, permissions):
-        config = original_get_room_config(room, permissions)
+    def get_room_config(room, permissions, **kwargs):
+        config = original_get_room_config(room, permissions, **kwargs)
         augment_room_config(room, config)
         return config
 


### PR DESCRIPTION
This PR fixes two bugs in `get_room_config`:

1.  **AttributeError:** When testing with mock room objects, `room.event` could throw an `AttributeError` because mock objects sometimes don't have the event attribute initialized. This adds a safe `getattr(room, 'event', None)` check.
2.  **TypeError:** Eventyay core's `get_room_config` was modified to accept `current_stream` via `**kwargs`. The monkeypatch in this plugin was not forwarding `**kwargs`, which caused a fatal `TypeError: unexpected keyword argument 'current_stream'` when a room was being created and `push_room_info` was triggered. This fixes the signature to accept and forward `**kwargs`.

## Summary by Sourcery

Harden video integration room configuration against missing room events and evolving core service arguments.

Bug Fixes:
- Prevent room configuration augmentation from failing when a room has no initialized event.
- Forward additional keyword arguments through the patched room configuration service to support current_stream and other core API parameters.