### PR TITLE
feat: Integrate OAuth with Global Settings UI

### DIFF
--- a/interpretation/backends/voxbento_credentials.py
+++ b/interpretation/backends/voxbento_credentials.py
@@ -23,7 +23,14 @@ class VoxbentoError(Exception):
 
 
 def get_voxbento_base_url(event: Event) -> str:
-    url = event.settings.get(
+    from eventyay.base.settings import GlobalSettingsObject
+    
+    # Check Global Settings first
+    gs = GlobalSettingsObject().settings
+    global_url = gs.get("voxbento_base_url", "")
+    
+    # Fallback to legacy event-level settings
+    url = global_url or event.settings.get(
         SETTING_VOXBENTO_BASE_URL, default="", as_type=str
     ).strip()
     
@@ -44,7 +51,10 @@ def get_voxbento_api_key(event: Event) -> str:
 def is_voxbento_configured(event: Event | None) -> bool:
     if event is None:
         return False
-    return bool(get_voxbento_base_url(event) and get_voxbento_api_key(event))
+    from ..models import VoxbentoOAuthGrant
+    has_oauth = VoxbentoOAuthGrant.objects.filter(event=event).exists()
+    has_legacy = bool(get_voxbento_api_key(event))
+    return bool(get_voxbento_base_url(event) and (has_oauth or has_legacy))
 
 
 def save_voxbento_credentials(event: Event, base_url: str, api_key: str) -> None:

--- a/interpretation/backends/voxbento_oauth.py
+++ b/interpretation/backends/voxbento_oauth.py
@@ -24,9 +24,10 @@ class VoxbentoReauthorizationRequired(Exception):
 
 def call_voxbento_refresh(refresh_token, base_url):
     url = f"{base_url.rstrip('/')}/oauth/token"
-    from django.conf import settings
-    client_id = getattr(settings, "VOXBENTO_OAUTH_CLIENT_ID", "")
-    client_secret = getattr(settings, "VOXBENTO_OAUTH_CLIENT_SECRET", "")
+    from eventyay.base.settings import GlobalSettingsObject
+    gs = GlobalSettingsObject().settings
+    client_id = gs.get("voxbento_client_id", "")
+    client_secret = gs.get("voxbento_client_secret", "")
 
     try:
         response = requests.post(

--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -45,3 +45,40 @@ def navbar_entry_common(sender, request=None, **kwargs):
             "icon": "language",
         }
     ]
+
+from collections import OrderedDict
+from django import forms
+from eventyay.base.forms import SecretKeySettingsField
+from eventyay.base.signals import register_global_settings
+
+@receiver(register_global_settings, dispatch_uid="interpretation_global_settings")
+def register_voxbento_global_settings(sender, **kwargs):
+    return OrderedDict(
+        [
+            (
+                "voxbento_base_url",
+                forms.URLField(
+                    label=_("VoxBento Base URL"),
+                    required=False,
+                    help_text=_("The base URL of your VoxBento deployment (e.g. https://voxbento.example.com)."),
+                    widget=forms.URLInput(attrs={"placeholder": "https://voxbento.example.com"}),
+                ),
+            ),
+            (
+                "voxbento_client_id",
+                forms.CharField(
+                    label=_("VoxBento Client ID"),
+                    required=False,
+                    help_text=_("The OAuth Client ID obtained from the VoxBento Developer Dashboard."),
+                ),
+            ),
+            (
+                "voxbento_client_secret",
+                SecretKeySettingsField(
+                    label=_("VoxBento Client Secret"),
+                    required=False,
+                    help_text=_("The OAuth Client Secret obtained from the VoxBento Developer Dashboard."),
+                ),
+            ),
+        ]
+    )

--- a/interpretation/templates/interpretation/interpreters.html
+++ b/interpretation/templates/interpretation/interpreters.html
@@ -57,6 +57,16 @@
                             </form>
                         </div>
                     {% else %}
+                    {% if entry.id == "voxbento" %}
+                        <div class="interpretation-interpreter-connect-form">
+                            <p>
+                                {% trans "VoxBento is configured globally by the system administrator. Connect your event to VoxBento using OAuth." %}
+                            </p>
+                            <a href="{% url 'plugins:interpretation:oauth_connect' event=request.event.slug organizer=request.event.organizer.slug %}" class="btn btn-primary">
+                                <i class="fa fa-plug"></i> {% trans "Connect with VoxBento" %}
+                            </a>
+                        </div>
+                    {% else %}
                         <form method="post" class="interpretation-interpreter-connect-form">
                             {% csrf_token %}
                             <input type="hidden" name="interpretation_interpreter_id" value="{{ entry.id }}">
@@ -74,6 +84,7 @@
                                 {% trans "Sign in" %}
                             </button>
                         </form>
+                    {% endif %}
                     {% endif %}
                 {% else %}
                     <p class="text-muted">{% trans "No event sign-in required for this interpreter." %}</p>

--- a/interpretation/views_oauth.py
+++ b/interpretation/views_oauth.py
@@ -14,8 +14,8 @@ class VoxbentoOAuthConnectView(EventPermissionRequiredMixin, View):
 
     def get(self, request, *args, **kwargs):
         event = self.request.event
-        from django.conf import settings
-        client_id = getattr(settings, "VOXBENTO_OAUTH_CLIENT_ID", "")
+        from eventyay.base.settings import GlobalSettingsObject
+        client_id = GlobalSettingsObject().settings.get("voxbento_client_id", "")
         kwargs = {"organizer": event.organizer.slug, "event": event.slug}
         redirect_uri = self.request.build_absolute_uri(
             reverse("plugins:interpretation:oauth_callback", kwargs=kwargs)
@@ -46,8 +46,8 @@ class VoxbentoOAuthCallbackView(EventPermissionRequiredMixin, View):
             kwargs = {"organizer": event.organizer.slug, "event": event.slug}
             return redirect(reverse("plugins:interpretation:dashboard", kwargs=kwargs))
 
-        from django.conf import settings
-        client_id = getattr(settings, "VOXBENTO_OAUTH_CLIENT_ID", "")
+        from eventyay.base.settings import GlobalSettingsObject
+        client_id = GlobalSettingsObject().settings.get("voxbento_client_id", "")
         client_secret = getattr(settings, "VOXBENTO_OAUTH_CLIENT_SECRET", "")
         kwargs = {"organizer": event.organizer.slug, "event": event.slug}
         redirect_uri = self.request.build_absolute_uri(


### PR DESCRIPTION
Follow-up to #82. This PR replaces the hardcoded `.env` variables with dynamic Eventyay Global Settings using `GlobalSettingsObject`, re-injects the VoxBento configuration tab into the `global_settings` admin view, updates the frontend template to show the OAuth button, and patches a bug where `is_voxbento_configured` returned False for OAuth-only users.

### Dependencies
**This PR is explicitly linked with and requires fossasia/eventyay#5051** in order to successfully render the VoxBento configuration tab within the core Eventyay Global Settings UI.

### Testing Guide
1. Pull this branch (`feat/voxbento-ui-integration`) locally in your `eventyay-interpretation` plugin repository.
2. Ensure you have the core `eventyay` repository checked out to fossasia/eventyay#5051 (`feat/voxbento-global-settings`).
3. Start the Eventyay development server.
4. Navigate to Admin Dashboard -> Global Settings -> VoxBento tab (`/admin/global/settings/`).
5. Enter your VoxBento Base URL, Client ID, and Client Secret, and click save.
6. Navigate to an Event -> Interpretation -> Configure Interpreters (`/control/event/<organizer>/<event>/interpretation/interpreters/`).
7. Verify that the legacy API key form is completely gone and replaced by the "Connect with VoxBento" OAuth button.
8. Click "Connect with VoxBento" and verify it successfully redirects to the VoxBento developer dashboard authorization page.
9. Approve the authorization and verify it redirects back to Eventyay, successfully storing the encrypted OAuth token in the `interpretation_voxbentooauthgrant` table without throwing an error.