### PR TITLE
test: allow database access in RoomConfigureForm tests

### DIFF
--- a/tests/test_room_configure_form.py
+++ b/tests/test_room_configure_form.py
@@ -1,5 +1,7 @@
 """Tests for RoomConfigureForm."""
 
+import pytest
+
 from interpretation.forms import RoomConfigureForm
 from interpretation.models import RoomInterpretation
 
@@ -11,11 +13,6 @@ class _FakeEvent:
     def __int__(self):
         return self.id
 
-    id = 1
-    pk = 1
-    id = 1
-    pk = 1
-
     def get_plugins(self):
         return ["interpretation"]
 
@@ -25,6 +22,7 @@ class _FakeEvent:
             return default
 
 
+@pytest.mark.django_db
 def test_room_configure_form_lists_interpreters():
     form = RoomConfigureForm(event=_FakeEvent())
     ids = [choice[0] for choice in form.fields["interpreter"].choices]
@@ -32,6 +30,7 @@ def test_room_configure_form_lists_interpreters():
     assert RoomInterpretation.INTERPRETER_SUSI not in ids
 
 
+@pytest.mark.django_db
 def test_room_configure_form_accepts_interpreter_and_enabled():
     form = RoomConfigureForm(
         event=_FakeEvent(),

--- a/tests/test_room_configure_form.py
+++ b/tests/test_room_configure_form.py
@@ -22,7 +22,9 @@ class _FakeEvent:
             return default
 
 
-@pytest.mark.django_db
+pytestmark = pytest.mark.django_db
+
+
 def test_room_configure_form_lists_interpreters():
     form = RoomConfigureForm(event=_FakeEvent())
     ids = [choice[0] for choice in form.fields["interpreter"].choices]
@@ -30,7 +32,6 @@ def test_room_configure_form_lists_interpreters():
     assert RoomInterpretation.INTERPRETER_SUSI not in ids
 
 
-@pytest.mark.django_db
 def test_room_configure_form_accepts_interpreter_and_enabled():
     form = RoomConfigureForm(
         event=_FakeEvent(),


### PR DESCRIPTION
The tests in `test_room_configure_form.py` invoke `list_available_interpreters()`, which hits the database to check if VoxBento OAuth is configured. This PR adds the `@pytest.mark.django_db` decorator so pytest allows the database query instead of throwing a RuntimeError.

## Summary by Sourcery

Enable database-backed RoomConfigureForm tests and remove redundant test fixture definitions.

Bug Fixes:
- Allow RoomConfigureForm tests to perform the database access required when listing available interpreters.

Tests:
- Mark RoomConfigureForm tests as requiring Django database access.

Chores:
- Clean up redundant fake event attribute definitions.