### PR TITLE
fix(oauth): pass dynamic event slug to VoxBento instead of hardcoded testevent2

### DIFF
--- a/interpretation/views_oauth.py
+++ b/interpretation/views_oauth.py
@@ -56,7 +56,7 @@ class VoxbentoOAuthConnectView(EventPermissionRequiredMixin, View):
             f"&client_id={client_id}&redirect_uri={redirect_uri}"
             f"&scope={encoded_scope}"
             f"&code_challenge={challenge}&code_challenge_method=S256"
-            f"&event=testevent2"
+            f"&event={event.slug}"
             f"&state={state}"
         )
         return redirect(auth_url)


### PR DESCRIPTION
This PR replaces the hardcoded `testevent2` slug in the VoxBento OAuth URL with the dynamic `event.slug` of the current Eventyay event being configured.

## Summary by Sourcery

Bug Fixes:
- Use the current Eventyay event slug in the VoxBento OAuth flow instead of the hardcoded test event slug.