### PR TITLE
feat: implement VoxBento webhook dispatcher and handlers

### DIFF
--- a/interpretation/backends/voxbento_api.py
+++ b/interpretation/backends/voxbento_api.py
@@ -71,7 +71,7 @@ def subscribe_to_voxbento_webhooks(event: Event) -> None:
         target_url = get_webhook_target_url()
         payload = {
             "target_url": target_url,
-            "event_types": ["room.interpretation.started", "room.interpretation.stopped", "room.interpretation.failed"],
+            "event_types": ["booth.transcription.started", "booth.transcription.stopped", "booth.interpreter.joined"],
         }
 
         access_token = get_valid_access_token(grant.id)

--- a/interpretation/views_webhooks.py
+++ b/interpretation/views_webhooks.py
@@ -4,11 +4,11 @@ import json
 import logging
 import time
 
-from eventyay.base.models import Room
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+from eventyay.base.models import Room
 
 from .models import VoxbentoOAuthGrant
 

--- a/interpretation/views_webhooks.py
+++ b/interpretation/views_webhooks.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 
-from base.models import Room
+from eventyay.base.models import Room
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt

--- a/interpretation/views_webhooks.py
+++ b/interpretation/views_webhooks.py
@@ -4,6 +4,7 @@ import json
 import logging
 import time
 
+from base.models import Room
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -63,6 +64,81 @@ class VoxbentoWebhookReceiverView(View):
             return JsonResponse({"detail": "Invalid signature"}, status=401)
 
         event_type = payload.get("event_type")
+        data = payload.get("data", {})
         logger.info("Received valid VoxBento webhook for event %s: %s", event_slug, event_type)
 
+        handlers = {
+            "booth.transcription.started": self.handle_transcription_started,
+            "booth.transcription.stopped": self.handle_transcription_stopped,
+            "booth.interpreter.joined": self.handle_interpreter_joined,
+        }
+
+        handler = handlers.get(event_type)
+        if handler:
+            handler(grant.event, data)
+
         return HttpResponse("OK", status=200)
+
+    def _get_room_from_booth_id(self, event, booth_id):
+        if not booth_id:
+            return None
+        # booth_id format is event_slug-room_id-language_code
+        parts = booth_id.rsplit("-", 2)
+        if len(parts) != 3:
+            return None
+
+        try:
+            room_id = int(parts[1])
+            return Room.objects.get(id=room_id, event=event)
+        except (ValueError, Room.DoesNotExist):
+            return None
+
+    def handle_transcription_started(self, event, data):
+        room = self._get_room_from_booth_id(event, data.get("booth_id"))
+        if not room or not hasattr(room, "interpretation"):
+            return
+
+        interp = room.interpretation
+        interp.status = interp.STATUS_RUNNING
+        interp.backend_session_id = data.get("session_id", "")
+        interp.save(update_fields=["status", "backend_session_id"])
+
+        from .video_integration import notify_video_room_config_changed
+
+        notify_video_room_config_changed(event)
+
+    def handle_transcription_stopped(self, event, data):
+        room = self._get_room_from_booth_id(event, data.get("booth_id"))
+        if not room or not hasattr(room, "interpretation"):
+            return
+
+        interp = room.interpretation
+        interp.status = interp.STATUS_IDLE
+        interp.backend_session_id = ""
+        interp.save(update_fields=["status", "backend_session_id"])
+
+        from .video_integration import notify_video_room_config_changed
+
+        notify_video_room_config_changed(event)
+
+    def handle_interpreter_joined(self, event, data):
+        room = self._get_room_from_booth_id(event, data.get("booth_id"))
+        if not room or not hasattr(room, "interpretation"):
+            return
+
+        interp = room.interpretation
+        config = interp.backend_config
+        active = config.get("active_interpreters", [])
+
+        participant = {
+            "participant_id": data.get("participant_id"),
+            "display_name": data.get("display_name"),
+            "language": data.get("language"),
+        }
+
+        # Avoid exact duplicates
+        if participant not in active:
+            active.append(participant)
+            config["active_interpreters"] = active
+            interp.backend_config = config
+            interp.save(update_fields=["backend_config"])


### PR DESCRIPTION
solves (Phases 4.3a and 4.3b) of #92 

This PR:
- Replaces the generic `200 OK` in `VoxbentoWebhookReceiverView` with a proper dispatcher for transcription and interpreter events.
- Maps `booth.transcription.started/stopped` to the `RoomInterpretation` status, allowing the frontend to know when VoxBento is active.
- Triggers `notify_video_room_config_changed` so the frontend UI re-fetches the live URLs dynamically.
- Updates the webhook subscription in `voxbento_api.py` to use the correct event types.

## Summary by Sourcery

Integrate VoxBento event and room lifecycle synchronization with webhook-driven interpretation state updates.

New Features:
- Provision and synchronize VoxBento events and rooms, including lifecycle operations and connection status tracking.
- Add confirmation-based UI controls for permanently deleting a VoxBento event and its associated data.

Bug Fixes:
- Handle VoxBento transcription and interpreter webhook events instead of returning a generic acknowledgement.
- Update webhook subscriptions to use the current booth transcription and interpreter event types.
- Refresh interpretation status and video-room configuration when transcription sessions start or stop.

Enhancements:
- Expose VoxBento provisioning, webhook, and room synchronization status in the interpretation overview.
- Expand OAuth permissions to support event provisioning and add background synchronization on event and room changes.

Chores:
- Add persistence fields and migrations for VoxBento event provisioning and room synchronization outcomes.

## Summary by Sourcery

Synchronize VoxBento interpretation and frontend room state through dedicated webhook event handling.

Bug Fixes:
- Handle VoxBento transcription and interpreter webhook events instead of returning only a generic acknowledgement.
- Synchronize interpretation state and active interpreter information when VoxBento booth events occur.

Enhancements:
- Notify the frontend when transcription sessions change so live video-room configuration can be refreshed dynamically.

Chores:
- Update VoxBento webhook subscriptions to use the current booth transcription and interpreter event types.

## Summary by Sourcery

Synchronize interpretation state and frontend video-room configuration with VoxBento booth webhook events.

New Features:
- Handle VoxBento transcription and interpreter webhook events to synchronize interpretation sessions and active interpreters.

Bug Fixes:
- Replace generic webhook acknowledgements with event-specific processing for supported VoxBento booth events.

Enhancements:
- Update VoxBento webhook subscriptions to use the current booth transcription and interpreter event types.
- Notify the frontend when transcription sessions start or stop so live video-room configuration stays current.