### PR TITLE
fix(webhooks): log and save webhook subscription failures

### DIFF
--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -49,7 +49,12 @@ def sync_voxbento_connection(self, event_id: int) -> None:
             subscribe_to_voxbento_webhooks(event)
         except requests.RequestException as e:
             if isinstance(e, requests.HTTPError) and e.response is not None and e.response.status_code < 500:
-                pass
+                logger.error(f"VoxBento webhook failed {e.response.status_code}: {e.response.text}")
+                from .models import VoxbentoOAuthGrant
+                VoxbentoOAuthGrant.objects.filter(
+                    id=grant.id,
+                    webhook_subscription_id__isnull=True
+                ).update(webhook_subscription_failed=True)
             else:
                 self.retry(exc=e)
 

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -51,10 +51,10 @@ def sync_voxbento_connection(self, event_id: int) -> None:
             if isinstance(e, requests.HTTPError) and e.response is not None and e.response.status_code < 500:
                 logger.error(f"VoxBento webhook failed {e.response.status_code}: {e.response.text}")
                 from .models import VoxbentoOAuthGrant
-                VoxbentoOAuthGrant.objects.filter(
-                    id=grant.id,
-                    webhook_subscription_id__isnull=True
-                ).update(webhook_subscription_failed=True)
+
+                VoxbentoOAuthGrant.objects.filter(id=grant.id, webhook_subscription_id__isnull=True).update(
+                    webhook_subscription_failed=True
+                )
             else:
                 self.retry(exc=e)
 


### PR DESCRIPTION
Fixes a bug where VoxBento webhook failures (e.g., 400 Bad Request for SSRF or 429 Too Many Requests) were silently swallowed by the celery task, leaving the grant in a confusing state with no error logs.

## Summary by Sourcery

Bug Fixes:
- Record and log non-retryable VoxBento webhook subscription failures so affected OAuth grants no longer remain in an ambiguous state.