### PR TITLE
fix: resolve ImportError on Save and WHEP URL mapping bug

### DIFF
--- a/interpretation/language_map.py
+++ b/interpretation/language_map.py
@@ -44,3 +44,11 @@ LANGUAGE_NAME_TO_CODE = load_language_map()
 def language_code_for_name(name):
     cleaned = str(name).strip()
     return LANGUAGE_NAME_TO_CODE.get(cleaned, cleaned.lower())
+
+
+def language_name_for_code(code):
+    cleaned_code = str(code).strip().lower()
+    for name, c in LANGUAGE_NAME_TO_CODE.items():
+        if str(c).strip().lower() == cleaned_code:
+            return name
+    return cleaned_code

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -168,7 +168,9 @@ def update_room_interpretation(room, event, data: dict) -> RoomInterpretation:
             if interpretation.interpreter == RoomInterpretation.INTERPRETER_VOXBENTO:
                 from .language_map import language_code_for_name
 
-                langs = [language_code_for_name(s["language"]) for s in validated_streams if s["language"] != "Original"]
+                langs = [
+                    language_code_for_name(s["language"]) for s in validated_streams if s["language"] != "Original"
+                ]
                 interpretation.target_languages = [lang_code for lang_code in langs if lang_code]
         except ValidationError as exc:
             raise ValueError(str(exc)) from exc

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -166,9 +166,9 @@ def update_room_interpretation(room, event, data: dict) -> RoomInterpretation:
             validated_streams = validate_language_streams(data.get("language_streams"))
             interpretation.language_streams = validated_streams
             if interpretation.interpreter == RoomInterpretation.INTERPRETER_VOXBENTO:
-                from .language_map import get_language_code
+                from .language_map import language_code_for_name
 
-                langs = [get_language_code(s["language"]) for s in validated_streams if s["language"] != "Original"]
+                langs = [language_code_for_name(s["language"]) for s in validated_streams if s["language"] != "Original"]
                 interpretation.target_languages = [lang_code for lang_code in langs if lang_code]
         except ValidationError as exc:
             raise ValueError(str(exc)) from exc

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -199,8 +199,9 @@ def _do_sync_single_room_to_voxbento(
                     # Convert to a dict to update/merge urls
                     stream_dict = {entry["language"]: entry for entry in new_streams if "language" in entry}
                     needs_save = False
-                    
+
                     from .language_map import language_code_for_name
+
                     # Create a reverse lookup for code -> Name
                     code_to_name = {language_code_for_name(name): name for name in stream_dict.keys()}
 

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -200,7 +200,7 @@ def _do_sync_single_room_to_voxbento(
                     stream_dict = {entry["language"]: entry for entry in new_streams if "language" in entry}
                     needs_save = False
 
-                    from .language_map import language_code_for_name
+                    from .language_map import language_code_for_name, language_name_for_code
 
                     # Create a reverse lookup for code -> Name
                     code_to_name = {language_code_for_name(name): name for name in stream_dict.keys()}
@@ -215,7 +215,8 @@ def _do_sync_single_room_to_voxbento(
                                     needs_save = True
                         else:
                             # Language added but wasn't in streams (edge case)
-                            stream_dict[lang_code] = {"language": lang_code, "youtube_id": full_url}
+                            resolved_name = language_name_for_code(lang_code)
+                            stream_dict[resolved_name] = {"language": resolved_name, "youtube_id": full_url}
                             needs_save = True
 
                     if needs_save:

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -199,17 +199,22 @@ def _do_sync_single_room_to_voxbento(
                     # Convert to a dict to update/merge urls
                     stream_dict = {entry["language"]: entry for entry in new_streams if "language" in entry}
                     needs_save = False
+                    
+                    from .language_map import language_code_for_name
+                    # Create a reverse lookup for code -> Name
+                    code_to_name = {language_code_for_name(name): name for name in stream_dict.keys()}
 
-                    for lang, full_url in returned_urls.items():
-                        if lang in stream_dict:
-                            existing = stream_dict[lang].get("youtube_id") or ""
+                    for lang_code, full_url in returned_urls.items():
+                        lang_name = code_to_name.get(lang_code)
+                        if lang_name and lang_name in stream_dict:
+                            existing = stream_dict[lang_name].get("youtube_id") or ""
                             if not existing or "/whep" in existing or "localhost" in existing:
                                 if existing != full_url:
-                                    stream_dict[lang]["youtube_id"] = full_url
+                                    stream_dict[lang_name]["youtube_id"] = full_url
                                     needs_save = True
                         else:
-                            # Language added but wasn't in streams
-                            stream_dict[lang] = {"language": lang, "youtube_id": full_url}
+                            # Language added but wasn't in streams (edge case)
+                            stream_dict[lang_code] = {"language": lang_code, "youtube_id": full_url}
                             needs_save = True
 
                     if needs_save:


### PR DESCRIPTION
Fixes a critical ImportError when saving room interpretation settings and fixes the logic that maps VoxBento language codes back to UI language names for WHEP URL injection.

## Summary by Sourcery

Fix VoxBento language mapping during room saves and WHEP URL synchronization.

Bug Fixes:
- Fix saving VoxBento room interpretation settings by using the correct language-code conversion helper.
- Correct WHEP URL mapping so returned language codes update or create the corresponding UI language streams.

Enhancements:
- Add reverse language-code lookup support for resolving VoxBento language codes to display names.